### PR TITLE
fix: Firebase deploy — Node 22 and webframeworks experiment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '25'
+          node-version: '22'
           cache: npm
 
       - name: Install dependencies
@@ -46,3 +46,5 @@ jobs:
           firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_FUNWITHFLAGS_5B62A }}
           channelId: live
           projectId: funwithflags-5b62a
+        env:
+          FIREBASE_CLI_EXPERIMENTS: webframeworks


### PR DESCRIPTION
Fixes the deploy workflow failures after PR #7 merged.

- **Node 22** — `firebase-tools` bundles `superstatic` which requires Node 20||22||24; Node 25 breaks it
- **`FIREBASE_CLI_EXPERIMENTS: webframeworks`** — required for the Firebase CLI to deploy a Next.js app via framework-aware hosting