### PR TITLE
feat: Firebase preview channel on PRs + fix Node version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ concurrency:
 permissions:
   contents: read
   pull-requests: write
+  checks: write
 
 jobs:
   ci:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,11 +10,13 @@ concurrency:
 
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   ci:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    environment: prd
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -22,7 +24,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '25'
+          node-version: '22'
           cache: npm
 
       - name: Install dependencies
@@ -43,3 +45,12 @@ jobs:
           NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID }}
           NEXT_PUBLIC_FIREBASE_APP_ID: ${{ secrets.NEXT_PUBLIC_FIREBASE_APP_ID }}
         run: npm run build
+
+      - name: Deploy preview to Firebase Hosting
+        uses: FirebaseExtended/action-hosting-deploy@v0
+        with:
+          repoToken: ${{ secrets.GITHUB_TOKEN }}
+          firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_FUNWITHFLAGS_5B62A }}
+          projectId: funwithflags-5b62a
+        env:
+          FIREBASE_CLI_EXPERIMENTS: webframeworks


### PR DESCRIPTION
## Changes

- **Preview channel deploy on every PR** — the CI job now deploys to a temporary Firebase Hosting preview URL before the PR can be merged. The PR only goes green if lint + tests + build + deploy all pass.
- **Node 22 in CI** — aligns with deploy workflow (superstatic requires 20||22||24)
- **`environment: prd`** added to CI job — exposes the `prd` environment secrets (Firebase service account, NEXT_PUBLIC_* vars) to the CI job
- **`pull-requests: write` permission** — needed for the Firebase action to post the preview URL as a PR comment

## ⚠️ Manual GCP steps required before this can succeed

The service account needs additional permissions. In **Google Cloud Console → IAM & Admin → IAM**:
1. Find the Firebase service account → Add roles: `Cloud Functions Admin`, `Cloud Run Admin`, `Service Account User`
2. Enable Cloud Functions API: https://console.cloud.google.com/apis/library/cloudfunctions.googleapis.com?project=funwithflags-5b62a
3. Enable Cloud Run API: https://console.cloud.google.com/apis/library/run.googleapis.com?project=funwithflags-5b62a