### PR TITLE
feat: switch deployment to Vercel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
   ci:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    environment: prd
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -22,7 +23,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '25'
+          node-version: '22'
           cache: npm
 
       - name: Install dependencies

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,50 +1,9 @@
-name: Deploy to Firebase
+name: Deploy to Vercel
 
+# Vercel's GitHub integration handles deployment automatically.
+# This workflow is intentionally empty — Vercel deploys:
+#   - Production: on every push to main
+#   - Preview:    on every pull request
+# No secrets or configuration needed here.
 on:
-  push:
-    branches: [main]
-
-concurrency:
-  group: deploy-${{ github.ref }}
-  cancel-in-progress: true
-
-permissions:
-  contents: read
-
-jobs:
-  deploy:
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    environment: prd
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: '22'
-          cache: npm
-
-      - name: Install dependencies
-        run: npm install
-
-      - name: Build
-        env:
-          NEXT_PUBLIC_FIREBASE_API_KEY: ${{ secrets.NEXT_PUBLIC_FIREBASE_API_KEY }}
-          NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN: ${{ secrets.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN }}
-          NEXT_PUBLIC_FIREBASE_PROJECT_ID: ${{ secrets.NEXT_PUBLIC_FIREBASE_PROJECT_ID }}
-          NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET: ${{ secrets.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET }}
-          NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID }}
-          NEXT_PUBLIC_FIREBASE_APP_ID: ${{ secrets.NEXT_PUBLIC_FIREBASE_APP_ID }}
-        run: npm run build
-
-      - name: Deploy to Firebase Hosting
-        uses: FirebaseExtended/action-hosting-deploy@v0
-        with:
-          repoToken: ${{ secrets.GITHUB_TOKEN }}
-          firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_FUNWITHFLAGS_5B62A }}
-          channelId: live
-          projectId: funwithflags-5b62a
-        env:
-          FIREBASE_CLI_EXPERIMENTS: webframeworks
+  workflow_dispatch: # manual trigger only, kept for reference

--- a/firebase.json
+++ b/firebase.json
@@ -1,14 +1,11 @@
 {
   "hosting": {
-    "source": ".",
+    "public": "out",
     "ignore": [
       "firebase.json",
       "**/.*",
       "**/node_modules/**"
     ],
-    "frameworksBackend": {
-      "region": "us-central1"
-    },
     "headers": [
       {
         "source": "**",


### PR DESCRIPTION
Replaces Firebase Hosting deployment with Vercel.

- CI workflow: lint → test → build (clean, no deployment step — Vercel handles previews natively via GitHub integration)
- deploy.yml: emptied (Vercel's GitHub app auto-deploys on push to main)
- firebase.json: removed Cloud Run/Functions backend config (Firebase Auth + Firestore still work — they are client-side only)