### PR TITLE
fix: resolve DYNAMIC_SERVER_USAGE and invalid deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,3 +7,9 @@ name: Deploy to Vercel
 # No secrets or configuration needed here.
 on:
   workflow_dispatch: # manual trigger only, kept for reference
+
+jobs:
+  noop:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Deployments are handled by Vercel's GitHub integration."

--- a/src/app/[locale]/catalog/CatalogContent.tsx
+++ b/src/app/[locale]/catalog/CatalogContent.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import { useTranslations } from "next-intl";
+import { useCountries } from "@/lib/providers/CountriesProvider";
+import { filterByContinent, searchCountries } from "@/lib/utils/countries";
+import { useContinentFilter } from "@/lib/hooks/useContinentFilter";
+import { AppShell } from "@/components/layout/AppShell";
+import { CountryGrid } from "@/components/catalog/CountryGrid";
+
+export function CatalogContent() {
+  const t = useTranslations("catalog");
+  const { countries } = useCountries();
+  const [searchQuery, setSearchQuery] = useState("");
+  const { activeContinent } = useContinentFilter();
+
+  const filteredCountries = useMemo(() => {
+    let result = filterByContinent(countries, activeContinent);
+    result = searchCountries(result, searchQuery);
+    return result;
+  }, [countries, activeContinent, searchQuery]);
+
+  return (
+    <AppShell searchQuery={searchQuery} onSearchChange={setSearchQuery}>
+      <header className="mb-12">
+        <h1 className="text-5xl md:text-6xl font-extrabold text-on-background tracking-tighter mb-4">
+          {t("title")}
+        </h1>
+        <p className="text-on-surface-variant text-lg max-w-2xl leading-relaxed">
+          {t("subtitle")}
+        </p>
+      </header>
+      <CountryGrid countries={filteredCountries} />
+    </AppShell>
+  );
+}

--- a/src/app/[locale]/catalog/page.tsx
+++ b/src/app/[locale]/catalog/page.tsx
@@ -1,39 +1,5 @@
-"use client";
-
-import { useState, useMemo, Suspense } from "react";
-import { useTranslations } from "next-intl";
-import { useCountries } from "@/lib/providers/CountriesProvider";
-import { filterByContinent, searchCountries } from "@/lib/utils/countries";
-import { useContinentFilter } from "@/lib/hooks/useContinentFilter";
-import { AppShell } from "@/components/layout/AppShell";
-import { CountryGrid } from "@/components/catalog/CountryGrid";
-
-function CatalogContent() {
-  const t = useTranslations("catalog");
-  const { countries } = useCountries();
-  const [searchQuery, setSearchQuery] = useState("");
-  const { activeContinent } = useContinentFilter();
-
-  const filteredCountries = useMemo(() => {
-    let result = filterByContinent(countries, activeContinent);
-    result = searchCountries(result, searchQuery);
-    return result;
-  }, [countries, activeContinent, searchQuery]);
-
-  return (
-    <AppShell searchQuery={searchQuery} onSearchChange={setSearchQuery}>
-      <header className="mb-12">
-        <h1 className="text-5xl md:text-6xl font-extrabold text-on-background tracking-tighter mb-4">
-          {t("title")}
-        </h1>
-        <p className="text-on-surface-variant text-lg max-w-2xl leading-relaxed">
-          {t("subtitle")}
-        </p>
-      </header>
-      <CountryGrid countries={filteredCountries} />
-    </AppShell>
-  );
-}
+import { Suspense } from "react";
+import { CatalogContent } from "./CatalogContent";
 
 export default function CatalogPage() {
   return (

--- a/src/app/[locale]/games/guess-the-flag/GameContent.tsx
+++ b/src/app/[locale]/games/guess-the-flag/GameContent.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { useMemo } from "react";
+import { useCountries } from "@/lib/providers/CountriesProvider";
+import { filterByContinent } from "@/lib/utils/countries";
+import { useContinentFilter } from "@/lib/hooks/useContinentFilter";
+import { useUserProgress } from "@/lib/hooks/useUserProgress";
+import { AppShell } from "@/components/layout/AppShell";
+import { FlagQuiz } from "@/components/games/FlagQuiz";
+
+export function GameContent() {
+  const { countries } = useCountries();
+  const { activeContinent } = useContinentFilter();
+  const { saveQuizScore } = useUserProgress();
+
+  const pool = useMemo(
+    () => filterByContinent(countries, activeContinent),
+    [countries, activeContinent],
+  );
+
+  return (
+    <AppShell>
+      <div className="max-w-4xl mx-auto">
+        <FlagQuiz pool={pool} onGameOver={saveQuizScore} />
+      </div>
+    </AppShell>
+  );
+}

--- a/src/app/[locale]/games/guess-the-flag/page.tsx
+++ b/src/app/[locale]/games/guess-the-flag/page.tsx
@@ -1,36 +1,10 @@
-"use client";
-
-import { Suspense, useMemo } from "react";
-import { useCountries } from "@/lib/providers/CountriesProvider";
-import { filterByContinent } from "@/lib/utils/countries";
-import { useContinentFilter } from "@/lib/hooks/useContinentFilter";
-import { useUserProgress } from "@/lib/hooks/useUserProgress";
-import { AppShell } from "@/components/layout/AppShell";
-import { FlagQuiz } from "@/components/games/FlagQuiz";
-
-function GuessTheFlagContent() {
-  const { countries } = useCountries();
-  const { activeContinent } = useContinentFilter();
-  const { saveQuizScore } = useUserProgress();
-
-  const pool = useMemo(
-    () => filterByContinent(countries, activeContinent),
-    [countries, activeContinent],
-  );
-
-  return (
-    <AppShell>
-      <div className="max-w-4xl mx-auto">
-        <FlagQuiz pool={pool} onGameOver={saveQuizScore} />
-      </div>
-    </AppShell>
-  );
-}
+import { Suspense } from "react";
+import { GameContent } from "./GameContent";
 
 export default function GuessTheFlagPage() {
   return (
     <Suspense>
-      <GuessTheFlagContent />
+      <GameContent />
     </Suspense>
   );
 }


### PR DESCRIPTION
## What

Two issues found from PR #10:

### 1. `deploy.yml` — invalid workflow file
GitHub Actions requires at least one `jobs:` key. Added a minimal no-op job so the workflow file is valid while Vercel still handles actual deployment.

### 2. `FUNCTION_INVOCATION_FAILED` on Catalog (and Games) page
**Root cause:** Pages used `"use client"` at the file level while also using `useSearchParams()` (via `useContinentFilter`). In Next.js App Router, `useSearchParams()` must be wrapped in a `Suspense` boundary owned by a **Server Component** — otherwise the `DynamicServerError` propagates as `FUNCTION_INVOCATION_FAILED` on Vercel.

**Fix:** Applied the canonical Next.js pattern:
- `page.tsx` becomes a Server Component that provides the `Suspense` boundary
- The interactive content is extracted to a separate `"use client"` file

### Files changed
- `.github/workflows/deploy.yml` — add required `jobs` key
- `catalog/page.tsx` → Server Component shell
- `catalog/CatalogContent.tsx` → new client component (extracted)
- `games/guess-the-flag/page.tsx` → Server Component shell
- `games/guess-the-flag/GameContent.tsx` → new client component (extracted)