### PR TITLE
fix: setRequestLocale for static rendering of country detail pages

### DIFF
--- a/src/app/[locale]/catalog/[countrySlug]/page.tsx
+++ b/src/app/[locale]/catalog/[countrySlug]/page.tsx
@@ -1,3 +1,4 @@
+import { setRequestLocale } from "next-intl/server";
 import { getCountryBySlug, getCountrySlugs } from "@/lib/utils/countries";
 import { CountryDetailHeader } from "@/components/country/CountryDetailHeader";
 import { CountryDetailContent } from "@/components/country/CountryDetailContent";
@@ -12,9 +13,10 @@ export function generateStaticParams() {
 export async function generateMetadata({
   params,
 }: {
-  params: Promise<{ countrySlug: string }>;
+  params: Promise<{ locale: string; countrySlug: string }>;
 }) {
-  const { countrySlug } = await params;
+  const { locale, countrySlug } = await params;
+  setRequestLocale(locale);
   const country = getCountryBySlug(countrySlug);
   if (!country) return { title: "Country — Explorer's Atlas" };
   return {
@@ -26,9 +28,10 @@ export async function generateMetadata({
 export default async function CountryDetailPage({
   params,
 }: {
-  params: Promise<{ countrySlug: string }>;
+  params: Promise<{ locale: string; countrySlug: string }>;
 }) {
-  const { countrySlug } = await params;
+  const { locale, countrySlug } = await params;
+  setRequestLocale(locale);
 
   return (
     <div className="min-h-screen bg-surface">

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -1,5 +1,5 @@
 import { NextIntlClientProvider } from "next-intl";
-import { getMessages } from "next-intl/server";
+import { getMessages, setRequestLocale } from "next-intl/server";
 import { Plus_Jakarta_Sans } from "next/font/google";
 import { notFound } from "next/navigation";
 import { routing } from "@/i18n/routing";
@@ -26,6 +26,8 @@ export default async function LocaleLayout({
   if (!routing.locales.includes(locale as "en" | "es")) {
     notFound();
   }
+
+  setRequestLocale(locale);
 
   const messages = await getMessages();
 


### PR DESCRIPTION
## Problem

Country detail pages (`/[locale]/catalog/[countrySlug]`) were failing with `DYNAMIC_SERVER_USAGE` on Vercel production:

```
GET /es/catalog/afghanistan → 500 FUNCTION_INVOCATION_FAILED
digest: 'DYNAMIC_SERVER_USAGE'
```

## Root cause

`[countrySlug]/page.tsx` has `generateStaticParams`, so Vercel attempts SSG/ISR pre-rendering at build time. During pre-rendering there is no HTTP request — `getMessages()` in the locale layout fell back to reading `headers()` to determine the locale, which throws `DYNAMIC_SERVER_USAGE`.

Pages without `generateStaticParams` (home, catalog listing, games, map) are always dynamically rendered and have a real HTTP request, so they work fine.

## Fix

Call `setRequestLocale(locale)` before `getMessages()` in:
- `[locale]/layout.tsx` — covers all child pages during pre-rendering
- `[countrySlug]/page.tsx` — `generateMetadata` + page component

This populates next-intl's async context with the locale from URL params so `getMessages()` never needs to read `headers()`, enabling static rendering to succeed.