### PR TITLE
chore: set Vercel production branch to main

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "github": {
+    "productionBranch": "main"
+  }
+}


### PR DESCRIPTION
Adds `vercel.json` with `github.productionBranch: main` so Vercel treats merges to `main` as production deployments instead of previews.