### PR TITLE
fix(catalog): prevent 404 on countries absent from static data

### DIFF
--- a/src/components/country/CountryDetailContent.tsx
+++ b/src/components/country/CountryDetailContent.tsx
@@ -9,9 +9,29 @@ import { RegionalContext } from "@/components/country/RegionalContext";
 import { DiscoverTracker } from "@/components/country/DiscoverTracker";
 
 export function CountryDetailContent({ slug }: { slug: string }) {
-  const { countries } = useCountries();
+  const { countries, enriching } = useCountries();
 
   const country = countries.find((c) => c.slug === slug);
+
+  // While Firestore enrichment is in progress, show a skeleton rather than
+  // immediately 404-ing — the country may exist in Firestore but not the
+  // static array (e.g. Jersey and other territories).
+  if (!country && enriching) {
+    return (
+      <div className="max-w-screen-xl mx-auto px-6 pt-12 pb-32 animate-pulse space-y-12">
+        <div className="h-64 bg-surface-container-low rounded-xl" />
+        <div className="grid grid-cols-1 md:grid-cols-12 gap-12">
+          <div className="md:col-span-7 space-y-8">
+            <div className="h-40 bg-surface-container-low rounded-xl" />
+            <div className="h-40 bg-surface-container-low rounded-xl" />
+          </div>
+          <div className="md:col-span-5">
+            <div className="h-64 bg-surface-container-low rounded-xl" />
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   if (!country) {
     notFound();


### PR DESCRIPTION
Closes #18

## Problem

Visiting `/es/catalog/jersey` (and ~137 other countries not in the static array) returned a 404 after the performance PR (#17).

## Root Cause

PR #17 removed the `loading` guard from `CountryDetailContent`. `src/data/countries.ts` contains only **58** countries with full rich content. The remaining ~137 countries exist only in Firestore.

`CountryDetailContent` was calling `notFound()` **synchronously** on first render, before `fetchAllCountries()` could resolve. Countries not in the 58-entry static array always 404'd immediately.

## Fix

Guard `notFound()` behind the `enriching` flag (introduced in #17):

- country not found AND `enriching === true` → show skeleton (wait for Firestore)
- country not found AND `enriching === false` → call `notFound()` (genuinely missing)

## Files Changed

| File | Change |
|---|---|
| `src/components/country/CountryDetailContent.tsx` | Guard `notFound()` behind `enriching`; restore skeleton for loading state |

## Testing

- [ ] Navigate to `/en/catalog/jersey` → shows skeleton briefly, then renders
- [ ] Navigate to `/en/catalog/not-a-real-country` → proper 404
- [ ] `npm test` — 31/31 passing