### PR TITLE
fix(routing): add generateStaticParams to locale layout

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -7,6 +7,10 @@ import { CountriesProvider } from "@/lib/providers/CountriesProvider";
 import { AuthProvider } from "@/lib/providers/AuthProvider";
 import "../globals.css";
 
+export function generateStaticParams() {
+  return routing.locales.map((locale) => ({ locale }));
+}
+
 const jakarta = Plus_Jakarta_Sans({
   subsets: ["latin"],
   variable: "--font-jakarta",


### PR DESCRIPTION
## Problem

`/es/catalog/<slug>` returns 404 in production for every country. Root cause: `[locale]/layout.tsx` was missing `generateStaticParams`.

In Next.js App Router, when a parent dynamic segment has no `generateStaticParams`, the child's function is called once without parent context — so only `/en/catalog/*` pages are pre-rendered at build. `dynamicParams = false` on the slug page then 404s every runtime request for `/es/catalog/*`.

## Fix

Added `generateStaticParams` to `[locale]/layout.tsx` returning both locales from `routing.locales`.

## Impact

Build now pre-renders **501 pages** (up from ~3), including all 245 countries × 2 locales = 490 country detail pages.

Closes #22