### PR TITLE
feat(catalog): make country card fully clickable

### DIFF
--- a/src/components/catalog/CountryCard.tsx
+++ b/src/components/catalog/CountryCard.tsx
@@ -14,7 +14,10 @@ export function CountryCard({ country }: CountryCardProps) {
   const t = useTranslations("catalog");
 
   return (
-    <div className="group bg-surface-container-low rounded-xl overflow-hidden hover:scale-[1.02] transition-bounce shadow-ambient flex flex-col">
+    <Link
+      href={`/catalog/${country.slug}`}
+      className="group bg-surface-container-low rounded-xl overflow-hidden hover:scale-[1.02] transition-bounce shadow-ambient flex flex-col"
+    >
       <div className="relative h-48 overflow-hidden bg-surface-container-highest">
         <Image
           src={`https://flagcdn.com/w320/${country.flagCode}.png`}
@@ -51,12 +54,12 @@ export function CountryCard({ country }: CountryCardProps) {
             </span>
           </div>
         </div>
-        <Link href={`/catalog/${country.slug}`} className="mt-auto">
+        <div className="mt-auto">
           <Button variant="primary" fullWidth>
             {t("exploreCulture")}
           </Button>
-        </Link>
+        </div>
       </div>
-    </div>
+    </Link>
   );
 }


### PR DESCRIPTION
## Summary
Makes the entire country card clickable, not just the 'Explore Culture' button.

## Changes
- Replaced outer `<div>` with `<Link>` in `CountryCard.tsx`
- Removed inner `<Link>` around the Button (Button remains visible as a visual element)

## Behaviour
- Clicking anywhere on the card (flag, name, capital, whitespace) navigates to the country detail page
- 'Explore Culture' button still visible for clarity
- Hover/group effects, keyboard navigation, and right-click 'Open in new tab' all preserved

Closes #26