### PR TITLE
feat(auth): kid-safe identity — nickname + DiceBear avatar + onboarding flow

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -93,5 +93,29 @@
     "anonymousLabel": "Playing as",
     "progressSummary": "{countries} countries · High score {score}",
     "close": "Close"
+  },
+  "onboarding": {
+    "title": "Explorer's Atlas",
+    "subtitle": "Your journey across the world starts here.",
+    "chooseAvatar": "Choose Your Avatar",
+    "yourName": "Your Explorer Name",
+    "namePlaceholder": "e.g. Captain Discovery",
+    "nameHint": "Choose a fun name that other explorers will see!",
+    "nameErrorShort": "Pick a name with at least 2 characters",
+    "nameErrorProfanity": "Hmm, let's try a different name! 🌍",
+    "levelBadge": "Level 1 Navigator",
+    "flagsFound": "Flags Found",
+    "stampRank": "Stamp Rank",
+    "startExploring": "Start Exploring!",
+    "profilePreview": "Profile Preview"
+  },
+  "profile": {
+    "title": "Your Profile",
+    "changeAvatar": "Change Avatar",
+    "nicknameLocked": "Your explorer name is locked in!",
+    "flagsFound": "Flags Found",
+    "highScore": "High Score",
+    "gamesPlayed": "Games Played",
+    "close": "Close"
   }
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -93,5 +93,29 @@
     "anonymousLabel": "Jugando como",
     "progressSummary": "{countries} países · Puntuación más alta {score}",
     "close": "Cerrar"
+  },
+  "onboarding": {
+    "title": "Atlas del Explorador",
+    "subtitle": "Tu viaje por el mundo comienza aquí.",
+    "chooseAvatar": "Elige tu Avatar",
+    "yourName": "Tu Nombre de Explorador",
+    "namePlaceholder": "ej. Capitán Descubridor",
+    "nameHint": "¡Elige un nombre divertido que otros exploradores verán!",
+    "nameErrorShort": "Elige un nombre de al menos 2 caracteres",
+    "nameErrorProfanity": "¡Vaya, intenta con un nombre diferente! 🌍",
+    "levelBadge": "Navegante Nivel 1",
+    "flagsFound": "Banderas Encontradas",
+    "stampRank": "Rango de Sellos",
+    "startExploring": "¡Empezar a Explorar!",
+    "profilePreview": "Vista Previa del Perfil"
+  },
+  "profile": {
+    "title": "Tu Perfil",
+    "changeAvatar": "Cambiar Avatar",
+    "nicknameLocked": "¡Tu nombre de explorador está bloqueado!",
+    "flagsFound": "Banderas Encontradas",
+    "highScore": "Puntuación Máxima",
+    "gamesPlayed": "Juegos Jugados",
+    "close": "Cerrar"
   }
 }

--- a/src/__tests__/utils/nickname.test.ts
+++ b/src/__tests__/utils/nickname.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { validateNickname } from "@/lib/utils/nickname";
+
+describe("validateNickname", () => {
+  it("returns null for a valid nickname", () => {
+    expect(validateNickname("CaptainDiscovery")).toBeNull();
+  });
+
+  it("returns error for empty string", () => {
+    expect(validateNickname("")).toBe("short");
+  });
+
+  it("returns error for single character", () => {
+    expect(validateNickname("A")).toBe("short");
+  });
+
+  it("returns null for exactly 2 characters", () => {
+    expect(validateNickname("Jo")).toBeNull();
+  });
+
+  it("returns null for exactly 20 characters", () => {
+    expect(validateNickname("A".repeat(20))).toBeNull();
+  });
+
+  it("returns error for 21 characters", () => {
+    expect(validateNickname("A".repeat(21))).toBe("long");
+  });
+
+  it("returns error for profanity", () => {
+    // "ass" is in the bad-words default list
+    expect(validateNickname("ass")).toBe("profanity");
+  });
+
+  it("trims whitespace before validation", () => {
+    expect(validateNickname("  A  ")).toBe("short");
+  });
+});

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -5,6 +5,7 @@ import { notFound } from "next/navigation";
 import { routing } from "@/i18n/routing";
 import { CountriesProvider } from "@/lib/providers/CountriesProvider";
 import { AuthProvider } from "@/lib/providers/AuthProvider";
+import { OnboardingGuard } from "@/components/auth/OnboardingGuard";
 import "../globals.css";
 
 export function generateStaticParams() {
@@ -53,6 +54,7 @@ export default async function LocaleLayout({
         <NextIntlClientProvider messages={messages}>
           <CountriesProvider>
             <AuthProvider>
+              <OnboardingGuard />
               {children}
             </AuthProvider>
           </CountriesProvider>

--- a/src/app/[locale]/onboarding/page.tsx
+++ b/src/app/[locale]/onboarding/page.tsx
@@ -1,0 +1,176 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useTranslations } from "next-intl";
+import Image from "next/image";
+import { useRouter } from "@/i18n/navigation";
+import { useAuth } from "@/lib/providers/AuthProvider";
+import { AvatarPicker, AVATAR_SEEDS } from "@/components/auth/AvatarPicker";
+import { validateNickname } from "@/lib/utils/nickname";
+import { avatarUrl } from "@/data/types";
+
+export default function OnboardingPage() {
+  const t = useTranslations("onboarding");
+  const router = useRouter();
+  const { isAnonymous, needsOnboarding, progress, completeOnboardingFlow } =
+    useAuth();
+
+  const [selectedSeed, setSelectedSeed] = useState<string>(AVATAR_SEEDS[0]);
+  const [nickname, setNickname] = useState("");
+  const [touched, setTouched] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+
+  // Redirect guards
+  useEffect(() => {
+    if (isAnonymous) {
+      router.replace("/");
+    } else if (!needsOnboarding) {
+      router.replace("/");
+    }
+  }, [isAnonymous, needsOnboarding, router]);
+
+  const error = touched ? validateNickname(nickname) : null;
+  const isValid = validateNickname(nickname) === null;
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setTouched(true);
+    if (!isValid || submitting) return;
+    setSubmitting(true);
+    try {
+      await completeOnboardingFlow(nickname.trim(), selectedSeed);
+      router.replace("/");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  const displayNickname = nickname.trim() || "Explorer";
+  const flagsFound = progress?.discoveredCountries.length ?? 0;
+
+  return (
+    <main className="min-h-screen bg-surface flex items-center justify-center p-4">
+      <div className="w-full max-w-4xl">
+        {/* Header */}
+        <div className="text-center mb-8">
+          <h1 className="text-3xl font-bold text-on-surface mb-2">{t("title")}</h1>
+          <p className="text-on-surface-variant">{t("subtitle")}</p>
+        </div>
+
+        <form onSubmit={handleSubmit}>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+            {/* Left panel — customisation */}
+            <div className="bg-surface-container rounded-3xl p-6 space-y-6">
+              {/* Avatar picker */}
+              <div>
+                <h2 className="text-lg font-semibold text-on-surface mb-4">
+                  {t("chooseAvatar")}
+                </h2>
+                <AvatarPicker selected={selectedSeed} onSelect={setSelectedSeed} />
+              </div>
+
+              {/* Nickname input */}
+              <div>
+                <label
+                  htmlFor="nickname"
+                  className="block text-sm font-medium text-on-surface mb-1"
+                >
+                  {t("yourName")}
+                </label>
+                <input
+                  id="nickname"
+                  type="text"
+                  value={nickname}
+                  placeholder={t("namePlaceholder")}
+                  maxLength={25}
+                  autoComplete="off"
+                  className={[
+                    "w-full rounded-xl border px-4 py-3 bg-surface text-on-surface placeholder:text-on-surface-variant focus:outline-none focus:ring-2 focus:ring-primary transition",
+                    error ? "border-error focus:ring-error" : "border-outline-variant",
+                  ].join(" ")}
+                  onChange={(e) => {
+                    setNickname(e.target.value);
+                    setTouched(true);
+                  }}
+                  onBlur={() => setTouched(true)}
+                />
+                {error === "short" || error === "profanity" ? (
+                  <p className="mt-1 text-sm text-error">
+                    {error === "short" ? t("nameErrorShort") : t("nameErrorProfanity")}
+                  </p>
+                ) : (
+                  <p className="mt-1 text-sm text-on-surface-variant">{t("nameHint")}</p>
+                )}
+              </div>
+            </div>
+
+            {/* Right panel — live preview */}
+            <div className="bg-surface-container rounded-3xl p-6 flex flex-col items-center justify-center space-y-4">
+              <p className="text-sm font-semibold text-on-surface-variant uppercase tracking-wider">
+                {t("profilePreview")}
+              </p>
+
+              {/* Avatar */}
+              <div className="w-28 h-28 rounded-full overflow-hidden ring-4 ring-primary bg-surface-variant">
+                <Image
+                  src={avatarUrl(selectedSeed)}
+                  alt="preview"
+                  width={112}
+                  height={112}
+                  className="w-full h-full object-cover"
+                  unoptimized
+                />
+              </div>
+
+              {/* Nickname */}
+              <p className="text-xl font-bold text-on-surface truncate max-w-full px-2 text-center">
+                {displayNickname}
+              </p>
+
+              {/* Level badge */}
+              <span className="inline-flex items-center gap-1 bg-primary/10 text-primary text-sm font-semibold px-3 py-1 rounded-full">
+                <span className="material-symbols-outlined text-[16px]">explore</span>
+                {t("levelBadge")}
+              </span>
+
+              {/* Stats row */}
+              <div className="flex gap-6 mt-2">
+                <div className="text-center">
+                  <p className="text-2xl font-bold text-on-surface">{flagsFound}</p>
+                  <p className="text-xs text-on-surface-variant">{t("flagsFound")}</p>
+                </div>
+                <div className="text-center">
+                  <p className="text-2xl font-bold text-on-surface">1</p>
+                  <p className="text-xs text-on-surface-variant">{t("stampRank")}</p>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/* CTA */}
+          <div className="mt-6 flex justify-center">
+            <button
+              type="submit"
+              disabled={!isValid || submitting}
+              className="px-8 py-4 rounded-2xl bg-primary text-on-primary font-bold text-lg shadow-lg hover:bg-primary/90 transition disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
+            >
+              {submitting ? (
+                <>
+                  <span className="material-symbols-outlined animate-spin text-[20px]">
+                    progress_activity
+                  </span>
+                  {t("startExploring")}
+                </>
+              ) : (
+                <>
+                  <span className="material-symbols-outlined text-[20px]">rocket_launch</span>
+                  {t("startExploring")}
+                </>
+              )}
+            </button>
+          </div>
+        </form>
+      </div>
+    </main>
+  );
+}

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -17,7 +17,7 @@ const DAY_OF_YEAR = Math.floor(
 function DashboardContent() {
   const t = useTranslations("home");
   const { countries } = useCountries();
-  const { progress, isAnonymous, displayName } = useAuth();
+  const { progress, isAnonymous, nickname } = useAuth();
 
   // Pick 4 countries daily — deterministic based on day-of-year (DAY_OF_YEAR computed at module load)
   const dailyCountries = useMemo(() => {
@@ -44,7 +44,7 @@ function DashboardContent() {
             {t("welcome")}
             <br />
             <span className="text-primary">
-              {isAnonymous ? t("adventurer") : `${displayName}!`}
+              {isAnonymous ? t("adventurer") : `${nickname}!`}
             </span>
           </h1>
           <p className="text-xl text-on-surface-variant max-w-2xl leading-[1.6]">

--- a/src/components/auth/AuthModal.tsx
+++ b/src/components/auth/AuthModal.tsx
@@ -11,7 +11,7 @@ type AuthModalProps = {
 
 export function AuthModal({ isOpen, onClose }: AuthModalProps) {
   const t = useTranslations("auth");
-  const { signInWithGoogle, displayName, progress } = useAuth();
+  const { signInWithGoogle, nickname, progress } = useAuth();
   const [isSigningIn, setIsSigningIn] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -80,7 +80,7 @@ export function AuthModal({ isOpen, onClose }: AuthModalProps) {
         {/* Current progress summary */}
         <div className="bg-surface-container-low rounded-xl p-4 mb-6 text-center">
           <p className="text-xs text-on-surface-variant mb-1">{t("anonymousLabel")}</p>
-          <p className="font-bold text-on-surface">{displayName}</p>
+          <p className="font-bold text-on-surface">{nickname}</p>
           <p className="text-xs text-on-surface-variant mt-1">
             {t("progressSummary", { countries: countriesCount, score: highScore })}
           </p>

--- a/src/components/auth/AvatarPicker.tsx
+++ b/src/components/auth/AvatarPicker.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import Image from "next/image";
+import { avatarUrl } from "@/data/types";
+
+export const AVATAR_SEEDS = [
+  "explorer",
+  "captain",
+  "navigator",
+  "pioneer",
+  "voyager",
+  "scout",
+  "ranger",
+  "pathfinder",
+  "discoverer",
+  "traveler",
+  "adventurer",
+  "wanderer",
+] as const;
+
+type Props = {
+  selected: string;
+  onSelect: (seed: string) => void;
+};
+
+export function AvatarPicker({ selected, onSelect }: Props) {
+  return (
+    <div className="grid grid-cols-4 gap-3">
+      {AVATAR_SEEDS.map((seed) => {
+        const isSelected = seed === selected;
+        return (
+          <button
+            key={seed}
+            type="button"
+            aria-label={`Avatar ${seed}`}
+            aria-pressed={isSelected}
+            onClick={() => onSelect(seed)}
+            className={[
+              "relative rounded-full overflow-hidden cursor-pointer transition-transform hover:scale-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary",
+              isSelected ? "ring-4 ring-primary" : "ring-2 ring-transparent",
+            ].join(" ")}
+          >
+            <Image
+              src={avatarUrl(seed)}
+              alt={seed}
+              width={64}
+              height={64}
+              className="w-full h-full object-cover bg-surface-variant"
+              unoptimized
+            />
+            {isSelected && (
+              <span className="absolute bottom-0 right-0 w-5 h-5 bg-secondary rounded-full flex items-center justify-center">
+                <span className="material-symbols-outlined text-white text-[12px]">
+                  check
+                </span>
+              </span>
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/auth/AvatarPicker.tsx
+++ b/src/components/auth/AvatarPicker.tsx
@@ -3,19 +3,20 @@
 import Image from "next/image";
 import { avatarUrl } from "@/data/types";
 
+// 12 seeds chosen to produce a roughly 50/50 male/female mix in fun-emoji style.
 export const AVATAR_SEEDS = [
-  "explorer",
-  "captain",
-  "navigator",
-  "pioneer",
-  "voyager",
-  "scout",
-  "ranger",
-  "pathfinder",
-  "discoverer",
-  "traveler",
-  "adventurer",
-  "wanderer",
+  "felix",
+  "luna",
+  "marco",
+  "nova",
+  "oliver",
+  "stella",
+  "rio",
+  "maya",
+  "leo",
+  "aria",
+  "finn",
+  "zoe",
 ] as const;
 
 type Props = {

--- a/src/components/auth/OnboardingGuard.tsx
+++ b/src/components/auth/OnboardingGuard.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { useEffect } from "react";
+import { usePathname, useRouter } from "@/i18n/navigation";
+import { useAuth } from "@/lib/providers/AuthProvider";
+
+/**
+ * Redirects authenticated users who haven't completed onboarding to /onboarding.
+ * Must be rendered inside AuthProvider.
+ */
+export function OnboardingGuard() {
+  const { needsOnboarding, loading } = useAuth();
+  const pathname = usePathname();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (loading) return;
+    if (needsOnboarding && pathname !== "/onboarding") {
+      router.replace("/onboarding");
+    }
+  }, [loading, needsOnboarding, pathname, router]);
+
+  return null;
+}

--- a/src/components/auth/ProfileDialog.tsx
+++ b/src/components/auth/ProfileDialog.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+import { useState } from "react";
+import { useTranslations } from "next-intl";
+import Image from "next/image";
+import { useAuth } from "@/lib/providers/AuthProvider";
+import { AvatarPicker } from "@/components/auth/AvatarPicker";
+import { avatarUrl } from "@/data/types";
+
+type Props = {
+  isOpen: boolean;
+  onClose: () => void;
+};
+
+export function ProfileDialog({ isOpen, onClose }: Props) {
+  const t = useTranslations("profile");
+  const tAuth = useTranslations("auth");
+  const { nickname, avatarSeed, progress, updateAvatarSeed, signOut } = useAuth();
+
+  const [changingAvatar, setChangingAvatar] = useState(false);
+  const [pendingSeed, setPendingSeed] = useState(avatarSeed);
+  const [saving, setSaving] = useState(false);
+
+  if (!isOpen) return null;
+
+  async function handleSaveAvatar() {
+    setSaving(true);
+    try {
+      await updateAvatarSeed(pendingSeed);
+      setChangingAvatar(false);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  function handleCancel() {
+    setPendingSeed(avatarSeed);
+    setChangingAvatar(false);
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-label={t("title")}
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div className="bg-surface rounded-3xl p-6 w-full max-w-sm shadow-2xl space-y-5">
+        {/* Header */}
+        <div className="flex items-center justify-between">
+          <h2 className="text-lg font-bold text-on-surface">{t("title")}</h2>
+          <button
+            type="button"
+            aria-label={t("close")}
+            onClick={onClose}
+            className="text-on-surface-variant hover:text-on-surface transition"
+          >
+            <span className="material-symbols-outlined">close</span>
+          </button>
+        </div>
+
+        {/* Avatar */}
+        <div className="flex flex-col items-center gap-3">
+          <div className="w-24 h-24 rounded-full overflow-hidden ring-4 ring-primary bg-surface-variant">
+            <Image
+              src={avatarUrl(changingAvatar ? pendingSeed : avatarSeed)}
+              alt={nickname}
+              width={96}
+              height={96}
+              className="w-full h-full object-cover"
+              unoptimized
+            />
+          </div>
+
+          {changingAvatar ? (
+            <div className="w-full space-y-3">
+              <AvatarPicker selected={pendingSeed} onSelect={setPendingSeed} />
+              <div className="flex gap-2">
+                <button
+                  type="button"
+                  onClick={handleCancel}
+                  className="flex-1 py-2 rounded-xl border border-outline-variant text-on-surface text-sm font-medium hover:bg-surface-variant transition"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="button"
+                  onClick={handleSaveAvatar}
+                  disabled={saving}
+                  className="flex-1 py-2 rounded-xl bg-primary text-on-primary text-sm font-semibold hover:bg-primary/90 transition disabled:opacity-50"
+                >
+                  {saving ? "Saving…" : "Save"}
+                </button>
+              </div>
+            </div>
+          ) : (
+            <button
+              type="button"
+              onClick={() => {
+                setPendingSeed(avatarSeed);
+                setChangingAvatar(true);
+              }}
+              className="text-sm text-primary font-semibold hover:underline"
+            >
+              {t("changeAvatar")}
+            </button>
+          )}
+        </div>
+
+        {/* Nickname (locked) */}
+        <div className="bg-surface-variant rounded-2xl px-4 py-3 flex items-center gap-3">
+          <span className="material-symbols-outlined text-on-surface-variant text-[20px]">
+            lock
+          </span>
+          <div>
+            <p className="font-semibold text-on-surface">{nickname}</p>
+            <p className="text-xs text-on-surface-variant">{t("nicknameLocked")}</p>
+          </div>
+        </div>
+
+        {/* Stats */}
+        <div className="grid grid-cols-3 gap-2 text-center">
+          <div className="bg-surface-variant rounded-2xl py-3">
+            <p className="text-xl font-bold text-on-surface">
+              {progress?.discoveredCountries.length ?? 0}
+            </p>
+            <p className="text-xs text-on-surface-variant">{t("flagsFound")}</p>
+          </div>
+          <div className="bg-surface-variant rounded-2xl py-3">
+            <p className="text-xl font-bold text-on-surface">
+              {progress?.quizHighScore ?? 0}
+            </p>
+            <p className="text-xs text-on-surface-variant">{t("highScore")}</p>
+          </div>
+          <div className="bg-surface-variant rounded-2xl py-3">
+            <p className="text-xl font-bold text-on-surface">
+              {progress?.quizGamesPlayed ?? 0}
+            </p>
+            <p className="text-xs text-on-surface-variant">{t("gamesPlayed")}</p>
+          </div>
+        </div>
+
+        {/* Sign out */}
+        <button
+          type="button"
+          onClick={signOut}
+          className="w-full text-center text-sm text-on-surface-variant hover:text-error transition"
+        >
+          {tAuth("signOut")}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/layout/TopNav.tsx
+++ b/src/components/layout/TopNav.tsx
@@ -7,6 +7,7 @@ import { SearchInput } from "@/components/ui/SearchInput";
 import { LanguageToggle } from "./LanguageToggle";
 import { useAuth } from "@/lib/providers/AuthProvider";
 import { AuthModal } from "@/components/auth/AuthModal";
+import { ProfileDialog } from "@/components/auth/ProfileDialog";
 
 type TopNavProps = {
   searchQuery?: string;
@@ -18,9 +19,9 @@ export function TopNav({ searchQuery, onSearchChange }: TopNavProps) {
   const tSearch = useTranslations("search");
   const tAuth = useTranslations("auth");
   const pathname = usePathname();
-  const { isAnonymous, displayName, avatarUrl, signOut } = useAuth();
+  const { isAnonymous, nickname, avatarUrl } = useAuth();
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const [isUserMenuOpen, setIsUserMenuOpen] = useState(false);
+  const [isProfileOpen, setIsProfileOpen] = useState(false);
 
   const navLinks = [
     { href: "/", label: t("home") },
@@ -100,61 +101,28 @@ export function TopNav({ searchQuery, onSearchChange }: TopNavProps) {
                 {tAuth("signIn")}
               </button>
             ) : (
-              <div className="relative">
-                <button
-                  onClick={() => setIsUserMenuOpen((v) => !v)}
-                  className="flex items-center gap-2 px-3 py-1.5 bg-surface-container-low rounded-full hover:bg-surface-container transition-bounce"
-                >
-                  {avatarUrl ? (
-                    // eslint-disable-next-line @next/next/no-img-element
-                    <img
-                      src={avatarUrl}
-                      alt={displayName}
-                      className="w-7 h-7 rounded-full object-cover"
-                      referrerPolicy="no-referrer"
-                    />
-                  ) : (
-                    <div className="w-7 h-7 rounded-full bg-primary-container flex items-center justify-center">
-                      <span className="material-symbols-outlined text-sm text-on-primary-container">
-                        person
-                      </span>
-                    </div>
-                  )}
-                  <span className="text-sm font-bold text-on-surface max-w-[120px] truncate hidden sm:block">
-                    {displayName}
-                  </span>
-                  <span className="material-symbols-outlined text-xs text-on-surface-variant">
-                    expand_more
-                  </span>
-                </button>
-
-                {isUserMenuOpen && (
-                  <>
-                    <div
-                      className="fixed inset-0 z-30"
-                      onClick={() => setIsUserMenuOpen(false)}
-                    />
-                    <div className="absolute right-0 top-full mt-2 bg-white/90 backdrop-blur-[24px] rounded-xl shadow-ambient py-1 min-w-[140px] z-40">
-                      <button
-                        onClick={async () => {
-                          setIsUserMenuOpen(false);
-                          await signOut();
-                        }}
-                        className="w-full text-left px-4 py-2.5 text-sm font-medium text-on-surface hover:bg-surface-container-low transition-colors flex items-center gap-2"
-                      >
-                        <span className="material-symbols-outlined text-sm">logout</span>
-                        {tAuth("signOut")}
-                      </button>
-                    </div>
-                  </>
-                )}
-              </div>
+              <button
+                onClick={() => setIsProfileOpen(true)}
+                className="flex items-center gap-2 px-3 py-1.5 bg-surface-container-low rounded-full hover:bg-surface-container transition-bounce"
+                aria-label="Open profile"
+              >
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img
+                  src={avatarUrl}
+                  alt={nickname}
+                  className="w-7 h-7 rounded-full object-cover"
+                />
+                <span className="text-sm font-bold text-on-surface max-w-[120px] truncate hidden sm:block">
+                  {nickname}
+                </span>
+              </button>
             )}
           </div>
         </div>
       </header>
 
       <AuthModal isOpen={isModalOpen} onClose={() => setIsModalOpen(false)} />
+      <ProfileDialog isOpen={isProfileOpen} onClose={() => setIsProfileOpen(false)} />
     </>
   );
 }

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -54,7 +54,7 @@ export type UserProgress = {
   lastPlayedAt: Date;
 };
 
-/** Derives a DiceBear adventurer SVG URL from an avatar seed. Never store this URL — store the seed. */
+/** Derives a DiceBear fun-emoji SVG URL from an avatar seed. Never store this URL — store the seed. */
 export function avatarUrl(seed: string): string {
-  return `https://api.dicebear.com/9.x/adventurer/svg?seed=${encodeURIComponent(seed)}`;
+  return `https://api.dicebear.com/9.x/fun-emoji/svg?seed=${encodeURIComponent(seed)}`;
 }

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -43,12 +43,18 @@ export type UserTier = "free" | "premium";
 
 export type UserProgress = {
   uid: string;
-  displayName: string;
+  nickname: string;
   isAnonymous: boolean;
-  avatarUrl?: string;
+  avatarSeed: string;
+  onboardingComplete: boolean;
   tier: UserTier;
   discoveredCountries: string[];
   quizHighScore: number;
   quizGamesPlayed: number;
   lastPlayedAt: Date;
 };
+
+/** Derives a DiceBear adventurer SVG URL from an avatar seed. Never store this URL — store the seed. */
+export function avatarUrl(seed: string): string {
+  return `https://api.dicebear.com/9.x/adventurer/svg?seed=${encodeURIComponent(seed)}`;
+}

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -102,29 +102,48 @@ export async function getUserProgress(
 
 export async function initUserProgress(
   uid: string,
-  options?: { displayName?: string; isAnonymous?: boolean; avatarUrl?: string },
+  options?: { nickname?: string; isAnonymous?: boolean; avatarSeed?: string },
 ): Promise<void> {
   const ref = doc(getDbClient(), "users", uid);
   const snap = await getDoc(ref);
   if (!snap.exists()) {
     await setDoc(ref, {
       uid,
-      displayName: options?.displayName ?? generatePseudonym(uid),
+      nickname: options?.nickname ?? generatePseudonym(uid),
       isAnonymous: options?.isAnonymous ?? true,
-      avatarUrl: options?.avatarUrl ?? null,
+      avatarSeed: options?.avatarSeed ?? uid,
+      onboardingComplete: false,
       tier: "free" as const,
       discoveredCountries: [],
       quizHighScore: 0,
       quizGamesPlayed: 0,
       lastPlayedAt: serverTimestamp(),
     });
-  } else if (options?.displayName || options?.avatarUrl !== undefined) {
+  } else {
     const updates: Record<string, unknown> = {};
-    if (options.displayName) updates.displayName = options.displayName;
-    if (options.avatarUrl !== undefined) updates.avatarUrl = options.avatarUrl;
-    if (options.isAnonymous !== undefined) updates.isAnonymous = options.isAnonymous;
-    await updateDoc(ref, updates);
+    if (options?.isAnonymous !== undefined) updates.isAnonymous = options.isAnonymous;
+    if (Object.keys(updates).length > 0) {
+      await updateDoc(ref, updates);
+    }
   }
+}
+
+export async function completeOnboarding(
+  uid: string,
+  nickname: string,
+  avatarSeed: string,
+): Promise<void> {
+  const ref = doc(getDbClient(), "users", uid);
+  await updateDoc(ref, {
+    nickname,
+    avatarSeed,
+    onboardingComplete: true,
+  });
+}
+
+export async function updateAvatar(uid: string, avatarSeed: string): Promise<void> {
+  const ref = doc(getDbClient(), "users", uid);
+  await updateDoc(ref, { avatarSeed });
 }
 
 export async function addDiscoveredCountry(
@@ -171,13 +190,9 @@ export async function linkAnonymousWithGoogle(): Promise<User> {
 
   try {
     const result = await linkWithPopup(currentUser, googleProvider);
-    // SUCCESS — same UID, now a Google account
-    const { displayName, photoURL, uid } = result.user;
-    await initUserProgress(uid, {
-      displayName: displayName ?? generatePseudonym(uid),
-      isAnonymous: false,
-      avatarUrl: photoURL ?? undefined,
-    });
+    // SUCCESS — same UID, now a Google account. Don't pass displayName/photoURL — onboarding will set nickname/avatarSeed.
+    const { uid } = result.user;
+    await initUserProgress(uid, { isAnonymous: false });
     return result.user;
   } catch (err: unknown) {
     const error = err as { code?: string; credential?: AuthCredential };
@@ -195,25 +210,9 @@ export async function linkAnonymousWithGoogle(): Promise<User> {
     const googleUid = googleResult.user.uid;
 
     // Always (re)create the Google user's doc in case it was deleted.
+    // Don't pass displayName/photoURL — onboarding will set nickname/avatarSeed.
     const googleProgress = await getUserProgress(googleUid);
-    // signInWithCredential leaves user.displayName/photoURL null in some Firebase
-    // versions — the canonical Google profile lives in providerData[0].
-    const googleProviderData = googleResult.user.providerData.find(
-      (p) => p.providerId === "google.com",
-    );
-    const gDisplayName =
-      googleResult.user.displayName ??
-      googleProviderData?.displayName ??
-      null;
-    const gPhotoURL =
-      googleResult.user.photoURL ??
-      googleProviderData?.photoURL ??
-      null;
-    await initUserProgress(googleUid, {
-      displayName: gDisplayName ?? generatePseudonym(googleUid),
-      isAnonymous: false,
-      avatarUrl: gPhotoURL ?? undefined,
-    });
+    await initUserProgress(googleUid, { isAnonymous: false });
     if (anonProgress) {
       const mergedDiscovered = Array.from(
         new Set([

--- a/src/lib/providers/AuthProvider.tsx
+++ b/src/lib/providers/AuthProvider.tsx
@@ -19,8 +19,12 @@ import {
   signOutUser,
   addDiscoveredCountry,
   updateQuizScore,
+  completeOnboarding,
+  updateAvatar,
+  generatePseudonym,
 } from "@/lib/firebase";
 import type { UserProgress, UserTier } from "@/data/types";
+import { avatarUrl as deriveAvatarUrl } from "@/data/types";
 import { hasAccess as checkAccess } from "@/lib/utils/access";
 import type { Feature } from "@/lib/utils/access";
 
@@ -29,14 +33,18 @@ type AuthContextValue = {
   progress: UserProgress | null;
   loading: boolean;
   isAnonymous: boolean;
-  displayName: string;
-  avatarUrl: string | null;
+  nickname: string;
+  avatarSeed: string;
+  avatarUrl: string;
+  needsOnboarding: boolean;
   tier: UserTier;
   hasAccess: (feature: Feature) => boolean;
   signInWithGoogle: () => Promise<void>;
   signOut: () => Promise<void>;
   discoverCountry: (slug: string) => Promise<void>;
   saveQuizScore: (score: number) => Promise<void>;
+  completeOnboardingFlow: (nickname: string, avatarSeed: string) => Promise<void>;
+  updateAvatarSeed: (avatarSeed: string) => Promise<void>;
 };
 
 const AuthContext = createContext<AuthContextValue | null>(null);
@@ -71,12 +79,6 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         setUser(firebaseUser);
         await initUserProgress(firebaseUser.uid, {
           isAnonymous: firebaseUser.isAnonymous,
-          ...(firebaseUser.displayName
-            ? { displayName: firebaseUser.displayName }
-            : {}),
-          ...(firebaseUser.photoURL !== undefined
-            ? { avatarUrl: firebaseUser.photoURL ?? undefined }
-            : {}),
         });
         const data = await getUserProgress(firebaseUser.uid);
         setProgress(data);
@@ -150,23 +152,35 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     [user],
   );
 
+  const completeOnboardingFlow = useCallback(
+    async (newNickname: string, newAvatarSeed: string) => {
+      if (!user) return;
+      await completeOnboarding(user.uid, newNickname, newAvatarSeed);
+      setProgress((prev) =>
+        prev
+          ? { ...prev, nickname: newNickname, avatarSeed: newAvatarSeed, onboardingComplete: true }
+          : prev,
+      );
+    },
+    [user],
+  );
+
+  const updateAvatarSeed = useCallback(
+    async (newSeed: string) => {
+      if (!user) return;
+      await updateAvatar(user.uid, newSeed);
+      setProgress((prev) =>
+        prev ? { ...prev, avatarSeed: newSeed } : prev,
+      );
+    },
+    [user],
+  );
+
   const isAnonymous = user?.isAnonymous ?? true;
-  // When signing in via signInWithCredential (credential-already-in-use path),
-  // Firebase Auth leaves user.displayName and user.photoURL as null — the
-  // actual Google profile is only in user.providerData[0]. Always check there.
-  const googleProvider = user?.providerData?.find((p) => p.providerId === "google.com");
-  // Fallback chain: User.displayName → providerData name → email username → Firestore → "Explorer"
-  const displayName = !isAnonymous
-    ? (user?.displayName ||
-       googleProvider?.displayName ||
-       (user?.email ? user.email.split("@")[0] : null) ||
-       progress?.displayName ||
-       "Explorer")
-    : (progress?.displayName ?? (user ? "Explorer" : ""));
-  // Fallback chain: User.photoURL → providerData photoURL → Firestore → null
-  const avatarUrl = !isAnonymous
-    ? (user?.photoURL || googleProvider?.photoURL || progress?.avatarUrl || null)
-    : (progress?.avatarUrl ?? null);
+  const nickname = progress?.nickname ?? (user ? generatePseudonym(user.uid) : "Explorer");
+  const avatarSeed = progress?.avatarSeed ?? (user?.uid ?? "explorer");
+  const avatarUrlValue = deriveAvatarUrl(avatarSeed);
+  const needsOnboarding = !isAnonymous && !(progress?.onboardingComplete ?? false);
 
   const tier: UserTier = progress?.tier ?? "free";
   const hasAccessFn = useCallback(
@@ -181,14 +195,18 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         progress,
         loading,
         isAnonymous,
-        displayName,
-        avatarUrl,
+        nickname,
+        avatarSeed,
+        avatarUrl: avatarUrlValue,
+        needsOnboarding,
         tier,
         hasAccess: hasAccessFn,
         signInWithGoogle,
         signOut: handleSignOut,
         discoverCountry,
         saveQuizScore,
+        completeOnboardingFlow,
+        updateAvatarSeed,
       }}
     >
       {children}

--- a/src/lib/utils/nickname.ts
+++ b/src/lib/utils/nickname.ts
@@ -1,0 +1,31 @@
+// Minimal blocklist for a kids' app. Extend as needed.
+// Intentionally short — defense-in-depth, not a complete filter.
+const BLOCKED_WORDS = [
+  "ass", "arse", "bastard", "bitch", "bollocks", "bugger", "cock", "crap",
+  "cunt", "damn", "dick", "fag", "fuck", "hell", "homo", "idiot", "jerk",
+  "kill", "moron", "nazi", "nigger", "penis", "piss", "prick", "pussy",
+  "rape", "retard", "sex", "shit", "slut", "spaz", "tit", "twat", "vagina",
+  "wank", "whore",
+];
+
+function containsBlockedWord(value: string): boolean {
+  const lower = value.toLowerCase();
+  return BLOCKED_WORDS.some(
+    (word) => lower === word || lower.includes(word),
+  );
+}
+
+export type NicknameError = "short" | "long" | "profanity";
+
+/**
+ * Validates a user-chosen nickname.
+ * Returns null if valid, or an error code if invalid.
+ */
+export function validateNickname(raw: string): NicknameError | null {
+  const value = raw.trim();
+  if (value.length < 2) return "short";
+  if (value.length > 20) return "long";
+  if (containsBlockedWord(value)) return "profanity";
+  return null;
+}
+


### PR DESCRIPTION
Closes #28

## What this PR does

Replaces Google PII (real name + profile photo) with an in-app kid-safe identity:

- **Onboarding screen** (`/onboarding`) shown once after first Google sign-in: pick one of 12 DiceBear `adventurer` avatars + choose an explorer nickname
- **Profanity filter** — inline blocklist in `validateNickname` (no third-party deps), blocks on submit
- **Nickname is permanent** (locked post-onboarding); avatar can be changed anytime via profile dialog
- **Profile dialog** in TopNav (replaces dropdown): shows avatar, locked nickname, stats, avatar picker, sign-out
- **Anonymous → Google progress continuity** preserved (already existed, untouched)
- **`OnboardingGuard`** client component redirects to `/onboarding` whenever `needsOnboarding` is true

## Changes

| File | Change |
|---|---|
| `src/data/types.ts` | Replace `displayName`/`avatarUrl` with `nickname`/`avatarSeed`/`onboardingComplete`; add `avatarUrl(seed)` helper |
| `src/lib/firebase.ts` | New `completeOnboarding()` + `updateAvatar()`; update `initUserProgress` schema |
| `src/lib/utils/nickname.ts` | `validateNickname` with inline profanity blocklist |
| `src/lib/providers/AuthProvider.tsx` | Expose `nickname`, `avatarSeed`, `avatarUrl`, `needsOnboarding`, `completeOnboardingFlow`, `updateAvatarSeed` |
| `src/components/auth/AvatarPicker.tsx` | 12-seed DiceBear avatar grid |
| `src/components/auth/ProfileDialog.tsx` | Profile sheet with avatar changer |
| `src/components/auth/OnboardingGuard.tsx` | Auto-redirect to onboarding |
| `src/app/[locale]/onboarding/page.tsx` | Onboarding page |
| `src/components/layout/TopNav.tsx` | Opens ProfileDialog, uses `nickname`/`avatarUrl` |
| `src/components/auth/AuthModal.tsx` | `displayName` → `nickname` |
| `src/app/[locale]/page.tsx` | `displayName` → `nickname` |
| `messages/en.json` + `es.json` | Add `onboarding` + `profile` i18n keys |

## Test results

```
Test Files  7 passed (7)
Tests       48 passed (48)
```

TypeScript: `npx tsc --noEmit` → no errors  
Build: ✅ `/en/onboarding` + `/es/onboarding` pre-rendered