### PR TITLE
feat(quiz): dynamic gameplay — difficulty picker, countdown timer, auto-advance

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -75,10 +75,17 @@
     "playAgain": "Play Again",
     "backToHome": "Back to Home",
     "whoAmI": "Who am I?",
-    "nextQuestion": "Next Question",
     "hintTitle": "Explorer's Hint",
     "currentScore": "Current Score",
-    "livesLeft": "Lives Left"
+    "livesLeft": "Lives Left",
+    "timeLeft": "TIME LEFT",
+    "selectDifficulty": "Choose Difficulty",
+    "easy": "Easy",
+    "normal": "Normal",
+    "hard": "Hard",
+    "easyDesc": "No time pressure",
+    "normalDesc": "5 seconds",
+    "hardDesc": "3 seconds"
   },
   "auth": {
     "signIn": "Sign In",

--- a/messages/es.json
+++ b/messages/es.json
@@ -75,10 +75,17 @@
     "playAgain": "Jugar de Nuevo",
     "backToHome": "Volver al Inicio",
     "whoAmI": "¿Quién soy?",
-    "nextQuestion": "Siguiente Pregunta",
     "hintTitle": "Pista del Explorador",
     "currentScore": "Puntuación Actual",
-    "livesLeft": "Vidas Restantes"
+    "livesLeft": "Vidas Restantes",
+    "timeLeft": "TIEMPO",
+    "selectDifficulty": "Elige Dificultad",
+    "easy": "Fácil",
+    "normal": "Normal",
+    "hard": "Difícil",
+    "easyDesc": "Sin límite de tiempo",
+    "normalDesc": "5 segundos",
+    "hardDesc": "3 segundos"
   },
   "auth": {
     "signIn": "Iniciar sesión",

--- a/src/__tests__/hooks/useGameState.test.ts
+++ b/src/__tests__/hooks/useGameState.test.ts
@@ -1,14 +1,15 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { renderHook, act } from "@testing-library/react";
 import { useGameState } from "@/lib/hooks/useGameState";
 import { countries } from "@/data/countries";
 
 describe("useGameState", () => {
-  it("starts in idle status", () => {
+  it("starts in idle status with default difficulty normal", () => {
     const { result } = renderHook(() => useGameState(countries));
     expect(result.current.state.status).toBe("idle");
     expect(result.current.state.score).toBe(0);
     expect(result.current.state.lives).toBe(3);
+    expect(result.current.state.difficulty).toBe("normal");
   });
 
   it("transitions to playing on startGame", () => {
@@ -21,7 +22,10 @@ describe("useGameState", () => {
 
   it("awards 100 points for a correct answer", () => {
     const { result } = renderHook(() => useGameState(countries));
-    act(() => result.current.startGame());
+    act(() => {
+      result.current.selectDifficulty("easy");
+      result.current.startGame();
+    });
     const correctSlug = result.current.state.currentQuestion!.correct.slug;
     act(() => result.current.submitAnswer(correctSlug));
     expect(result.current.state.status).toBe("correct");
@@ -31,7 +35,10 @@ describe("useGameState", () => {
 
   it("loses a life for a wrong answer", () => {
     const { result } = renderHook(() => useGameState(countries));
-    act(() => result.current.startGame());
+    act(() => {
+      result.current.selectDifficulty("easy");
+      result.current.startGame();
+    });
     const correctSlug = result.current.state.currentQuestion!.correct.slug;
     const wrongSlug = result.current.state.currentQuestion!.options.find(
       (o) => o.slug !== correctSlug,
@@ -42,21 +49,14 @@ describe("useGameState", () => {
     expect(result.current.state.score).toBe(0);
   });
 
-  it("advances to next question via nextQuestion", () => {
-    const { result } = renderHook(() => useGameState(countries));
-    act(() => result.current.startGame());
-    const correctSlug = result.current.state.currentQuestion!.correct.slug;
-    act(() => result.current.submitAnswer(correctSlug));
-    act(() => result.current.nextQuestion());
-    expect(result.current.state.status).toBe("playing");
-    expect(result.current.state.questionIndex).toBe(1);
-  });
-
   it("transitions to gameOver when lives reach 0", () => {
+    vi.useFakeTimers();
     const { result } = renderHook(() => useGameState(countries));
-    act(() => result.current.startGame());
+    act(() => {
+      result.current.selectDifficulty("easy");
+      result.current.startGame();
+    });
 
-    // Lose 3 lives
     for (let i = 0; i < 3; i++) {
       const correctSlug = result.current.state.currentQuestion!.correct.slug;
       const wrongSlug = result.current.state.currentQuestion!.options.find(
@@ -64,16 +64,22 @@ describe("useGameState", () => {
       )!.slug;
       act(() => result.current.submitAnswer(wrongSlug));
       if (i < 2) {
-        act(() => result.current.nextQuestion());
+        // Allow auto-advance to fire
+        act(() => vi.advanceTimersByTime(500));
       }
     }
     expect(result.current.state.status).toBe("gameOver");
     expect(result.current.state.lives).toBe(0);
+    vi.useRealTimers();
   });
 
   it("resets state on startGame after gameOver", () => {
+    vi.useFakeTimers();
     const { result } = renderHook(() => useGameState(countries));
-    act(() => result.current.startGame());
+    act(() => {
+      result.current.selectDifficulty("easy");
+      result.current.startGame();
+    });
 
     for (let i = 0; i < 3; i++) {
       const correctSlug = result.current.state.currentQuestion!.correct.slug;
@@ -81,7 +87,7 @@ describe("useGameState", () => {
         (o) => o.slug !== correctSlug,
       )!.slug;
       act(() => result.current.submitAnswer(wrongSlug));
-      if (i < 2) act(() => result.current.nextQuestion());
+      if (i < 2) act(() => vi.advanceTimersByTime(500));
     }
 
     act(() => result.current.startGame());
@@ -89,5 +95,205 @@ describe("useGameState", () => {
     expect(result.current.state.score).toBe(0);
     expect(result.current.state.lives).toBe(3);
     expect(result.current.state.questionIndex).toBe(0);
+    vi.useRealTimers();
+  });
+});
+
+describe("useGameState — difficulty", () => {
+  it("selectDifficulty updates difficulty when idle", () => {
+    const { result } = renderHook(() => useGameState(countries));
+    act(() => result.current.selectDifficulty("hard"));
+    expect(result.current.state.difficulty).toBe("hard");
+  });
+
+  it("selectDifficulty is ignored when not idle", () => {
+    const { result } = renderHook(() => useGameState(countries));
+    act(() => result.current.startGame());
+    act(() => result.current.selectDifficulty("easy"));
+    expect(result.current.state.difficulty).toBe("normal"); // unchanged
+  });
+
+  it("easy mode starts with null timeLeft", () => {
+    const { result } = renderHook(() => useGameState(countries));
+    act(() => {
+      result.current.selectDifficulty("easy");
+      result.current.startGame();
+    });
+    expect(result.current.state.timeLeft).toBeNull();
+  });
+
+  it("normal mode starts with timeLeft 5", () => {
+    const { result } = renderHook(() => useGameState(countries));
+    act(() => {
+      result.current.selectDifficulty("normal");
+      result.current.startGame();
+    });
+    expect(result.current.state.timeLeft).toBe(5);
+  });
+
+  it("hard mode starts with timeLeft 3", () => {
+    const { result } = renderHook(() => useGameState(countries));
+    act(() => {
+      result.current.selectDifficulty("hard");
+      result.current.startGame();
+    });
+    expect(result.current.state.timeLeft).toBe(3);
+  });
+
+  it("startGame preserves the selected difficulty", () => {
+    const { result } = renderHook(() => useGameState(countries));
+    act(() => result.current.selectDifficulty("hard"));
+    act(() => result.current.startGame());
+    expect(result.current.state.difficulty).toBe("hard");
+  });
+});
+
+describe("useGameState — timer", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it("counts down timeLeft by 1 each second", () => {
+    const { result } = renderHook(() => useGameState(countries));
+    act(() => {
+      result.current.selectDifficulty("normal");
+      result.current.startGame();
+    });
+    expect(result.current.state.timeLeft).toBe(5);
+
+    act(() => vi.advanceTimersByTime(1000));
+    expect(result.current.state.timeLeft).toBe(4);
+
+    act(() => vi.advanceTimersByTime(1000));
+    expect(result.current.state.timeLeft).toBe(3);
+  });
+
+  it("stops the timer when answer is submitted (easy mode stays null)", () => {
+    const { result } = renderHook(() => useGameState(countries));
+    act(() => {
+      result.current.selectDifficulty("easy");
+      result.current.startGame();
+    });
+
+    const correctSlug = result.current.state.currentQuestion!.correct.slug;
+    act(() => result.current.submitAnswer(correctSlug));
+
+    expect(result.current.state.timeLeft).toBeNull();
+    act(() => vi.advanceTimersByTime(2000));
+    expect(result.current.state.timeLeft).toBeNull(); // still null in easy mode
+  });
+
+  it("transitions to timeout and deducts a life when timer expires", () => {
+    const { result } = renderHook(() => useGameState(countries));
+    act(() => {
+      result.current.selectDifficulty("hard");
+      result.current.startGame();
+    });
+    expect(result.current.state.timeLeft).toBe(3);
+    expect(result.current.state.lives).toBe(3);
+
+    // Advance 3 ticks to reach timeLeft=0
+    act(() => vi.advanceTimersByTime(1000));
+    act(() => vi.advanceTimersByTime(1000));
+    act(() => vi.advanceTimersByTime(1000));
+
+    expect(result.current.state.status).toBe("timeout");
+    expect(result.current.state.lives).toBe(2);
+  });
+
+  it("transitions to gameOver when last life lost on timeout", () => {
+    const { result } = renderHook(() => useGameState(countries));
+    act(() => {
+      result.current.selectDifficulty("hard");
+      result.current.startGame();
+    });
+
+    // Lose 2 lives via wrong answers first
+    for (let i = 0; i < 2; i++) {
+      const correctSlug = result.current.state.currentQuestion!.correct.slug;
+      const wrongSlug = result.current.state.currentQuestion!.options.find(
+        (o) => o.slug !== correctSlug,
+      )!.slug;
+      act(() => result.current.submitAnswer(wrongSlug));
+      act(() => vi.advanceTimersByTime(500)); // auto-advance
+    }
+    expect(result.current.state.lives).toBe(1);
+
+    // Now let the timer expire on the last life
+    act(() => vi.advanceTimersByTime(1000));
+    act(() => vi.advanceTimersByTime(1000));
+    act(() => vi.advanceTimersByTime(1000));
+
+    expect(result.current.state.status).toBe("gameOver");
+    expect(result.current.state.lives).toBe(0);
+  });
+});
+
+describe("useGameState — auto-advance", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it("auto-advances to next question 500ms after correct answer", () => {
+    const { result } = renderHook(() => useGameState(countries));
+    act(() => {
+      result.current.selectDifficulty("easy");
+      result.current.startGame();
+    });
+    const correctSlug = result.current.state.currentQuestion!.correct.slug;
+    act(() => result.current.submitAnswer(correctSlug));
+    expect(result.current.state.status).toBe("correct");
+
+    act(() => vi.advanceTimersByTime(500));
+    expect(result.current.state.status).toBe("playing");
+    expect(result.current.state.questionIndex).toBe(1);
+  });
+
+  it("auto-advances to next question 500ms after wrong answer", () => {
+    const { result } = renderHook(() => useGameState(countries));
+    act(() => {
+      result.current.selectDifficulty("easy");
+      result.current.startGame();
+    });
+    const correctSlug = result.current.state.currentQuestion!.correct.slug;
+    const wrongSlug = result.current.state.currentQuestion!.options.find(
+      (o) => o.slug !== correctSlug,
+    )!.slug;
+    act(() => result.current.submitAnswer(wrongSlug));
+    expect(result.current.state.status).toBe("wrong");
+
+    act(() => vi.advanceTimersByTime(500));
+    expect(result.current.state.status).toBe("playing");
+    expect(result.current.state.questionIndex).toBe(1);
+  });
+
+  it("auto-advances after timeout", () => {
+    const { result } = renderHook(() => useGameState(countries));
+    act(() => {
+      result.current.selectDifficulty("hard");
+      result.current.startGame();
+    });
+
+    // Expire timer
+    act(() => vi.advanceTimersByTime(1000));
+    act(() => vi.advanceTimersByTime(1000));
+    act(() => vi.advanceTimersByTime(1000));
+    expect(result.current.state.status).toBe("timeout");
+
+    // Auto-advance fires
+    act(() => vi.advanceTimersByTime(500));
+    expect(result.current.state.status).toBe("playing");
+    expect(result.current.state.questionIndex).toBe(1);
+  });
+
+  it("does not advance before 500ms", () => {
+    const { result } = renderHook(() => useGameState(countries));
+    act(() => {
+      result.current.selectDifficulty("easy");
+      result.current.startGame();
+    });
+    const correctSlug = result.current.state.currentQuestion!.correct.slug;
+    act(() => result.current.submitAnswer(correctSlug));
+
+    act(() => vi.advanceTimersByTime(300));
+    expect(result.current.state.status).toBe("correct"); // still showing feedback
   });
 });

--- a/src/__tests__/hooks/useGameState.test.ts
+++ b/src/__tests__/hooks/useGameState.test.ts
@@ -191,10 +191,11 @@ describe("useGameState — timer", () => {
     expect(result.current.state.timeLeft).toBe(3);
     expect(result.current.state.lives).toBe(3);
 
-    // Advance 3 ticks to reach timeLeft=0
+    // Advance 3 ticks to reach timeLeft=0, then flush the deferred timeout handler
     act(() => vi.advanceTimersByTime(1000));
     act(() => vi.advanceTimersByTime(1000));
     act(() => vi.advanceTimersByTime(1000));
+    act(() => vi.advanceTimersByTime(0));
 
     expect(result.current.state.status).toBe("timeout");
     expect(result.current.state.lives).toBe(2);
@@ -222,6 +223,7 @@ describe("useGameState — timer", () => {
     act(() => vi.advanceTimersByTime(1000));
     act(() => vi.advanceTimersByTime(1000));
     act(() => vi.advanceTimersByTime(1000));
+    act(() => vi.advanceTimersByTime(0));
 
     expect(result.current.state.status).toBe("gameOver");
     expect(result.current.state.lives).toBe(0);
@@ -272,10 +274,11 @@ describe("useGameState — auto-advance", () => {
       result.current.startGame();
     });
 
-    // Expire timer
+    // Expire timer (flush the deferred timeout setState with +0ms)
     act(() => vi.advanceTimersByTime(1000));
     act(() => vi.advanceTimersByTime(1000));
     act(() => vi.advanceTimersByTime(1000));
+    act(() => vi.advanceTimersByTime(0));
     expect(result.current.state.status).toBe("timeout");
 
     // Auto-advance fires

--- a/src/components/games/AnswerOptions.tsx
+++ b/src/components/games/AnswerOptions.tsx
@@ -16,7 +16,7 @@ export function AnswerOptions({
   status,
   onSelect,
 }: AnswerOptionsProps) {
-  const isAnswered = status === "correct" || status === "wrong";
+  const isAnswered = status === "correct" || status === "wrong" || status === "timeout";
 
   function getOptionStyle(slug: string): string {
     if (!isAnswered) {
@@ -25,7 +25,8 @@ export function AnswerOptions({
     if (slug === correctSlug) {
       return "bg-secondary text-on-secondary";
     }
-    if (slug === selectedAnswer && slug !== correctSlug) {
+    // On timeout, no answer was selected — don't highlight anything red
+    if (status !== "timeout" && slug === selectedAnswer && slug !== correctSlug) {
       return "bg-error text-on-error";
     }
     return "bg-surface-container-highest opacity-50";

--- a/src/components/games/FlagQuiz.tsx
+++ b/src/components/games/FlagQuiz.tsx
@@ -2,13 +2,13 @@
 
 import { useEffect } from "react";
 import { useTranslations } from "next-intl";
-import { Country } from "@/data/types";
-import { useGameState } from "@/lib/hooks/useGameState";
+import { Country, Difficulty } from "@/data/types";
+import { useGameState, TIMER_DURATIONS } from "@/lib/hooks/useGameState";
 import { FlagDisplay } from "./FlagDisplay";
 import { AnswerOptions } from "./AnswerOptions";
 import { ScoreBoard } from "./ScoreBoard";
 import { LivesDisplay } from "./LivesDisplay";
-import { HintCard } from "./HintCard";
+import { TimerDisplay } from "./TimerDisplay";
 import { Button } from "@/components/ui/Button";
 import { Link } from "@/i18n/navigation";
 
@@ -17,9 +17,15 @@ type FlagQuizProps = {
   onGameOver?: (score: number) => void;
 };
 
+const DIFFICULTIES: { key: Difficulty; descKey: string }[] = [
+  { key: "easy", descKey: "easyDesc" },
+  { key: "normal", descKey: "normalDesc" },
+  { key: "hard", descKey: "hardDesc" },
+];
+
 export function FlagQuiz({ pool, onGameOver }: FlagQuizProps) {
   const t = useTranslations("quiz");
-  const { state, startGame, submitAnswer, nextQuestion } = useGameState(pool);
+  const { state, selectDifficulty, startGame, submitAnswer } = useGameState(pool);
 
   useEffect(() => {
     if (state.status === "gameOver" && onGameOver) {
@@ -40,6 +46,36 @@ export function FlagQuiz({ pool, onGameOver }: FlagQuizProps) {
         <p className="text-on-surface-variant text-lg text-center max-w-md leading-[1.6]">
           {t("subtitle")}
         </p>
+
+        {/* Difficulty picker */}
+        <div className="flex flex-col items-center gap-3 w-full max-w-sm">
+          <p className="text-sm font-bold uppercase tracking-widest text-on-surface-variant">
+            {t("selectDifficulty")}
+          </p>
+          <div className="flex gap-3 w-full">
+            {DIFFICULTIES.map(({ key, descKey }) => {
+              const isSelected = state.difficulty === key;
+              return (
+                <button
+                  key={key}
+                  onClick={() => selectDifficulty(key)}
+                  className={`
+                    flex-1 flex flex-col items-center gap-1 py-3 px-2 rounded-xl
+                    border-2 transition-bounce
+                    ${isSelected
+                      ? "bg-secondary-container text-on-secondary-container border-secondary"
+                      : "bg-surface-container text-on-surface-variant border-transparent hover:bg-surface-container-highest"
+                    }
+                  `}
+                >
+                  <span className="text-sm font-extrabold capitalize">{t(key)}</span>
+                  <span className="text-xs opacity-70">{t(descKey)}</span>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+
         <Button variant="primary" onClick={startGame}>
           <span className="flex items-center gap-2">
             <span className="material-symbols-outlined">play_arrow</span>
@@ -79,15 +115,21 @@ export function FlagQuiz({ pool, onGameOver }: FlagQuizProps) {
   }
 
   // Active game
-  const { currentQuestion, score, lives, selectedAnswer, status } = state;
+  const { currentQuestion, score, lives, selectedAnswer, status, difficulty, timeLeft } = state;
 
   if (!currentQuestion) return null;
 
+  const totalTime = TIMER_DURATIONS[difficulty];
+  const showTimer = difficulty !== "easy" && timeLeft !== null;
+
   return (
     <div className="flex flex-col items-center w-full">
-      {/* Score + Lives header */}
+      {/* Score + Timer + Lives header */}
       <div className="w-full flex justify-between items-end mb-10">
         <ScoreBoard score={score} />
+        {showTimer && (
+          <TimerDisplay timeLeft={timeLeft} totalTime={totalTime!} />
+        )}
         <LivesDisplay lives={lives} />
       </div>
 
@@ -107,23 +149,7 @@ export function FlagQuiz({ pool, onGameOver }: FlagQuizProps) {
         status={status}
         onSelect={submitAnswer}
       />
-
-      {/* Hint (shows after wrong answer) */}
-      {status === "wrong" && (
-        <HintCard hint={currentQuestion.correct.flagDescription} />
-      )}
-
-      {/* Next button (shows after answering) */}
-      {(status === "correct" || status === "wrong") && (
-        <div className="mt-8">
-          <Button variant="primary" onClick={nextQuestion}>
-            <span className="flex items-center gap-2">
-              <span className="material-symbols-outlined">arrow_forward</span>
-              {t("nextQuestion")}
-            </span>
-          </Button>
-        </div>
-      )}
     </div>
   );
 }
+

--- a/src/components/games/TimerDisplay.tsx
+++ b/src/components/games/TimerDisplay.tsx
@@ -1,0 +1,75 @@
+import { useTranslations } from "next-intl";
+
+type TimerDisplayProps = {
+  timeLeft: number;
+  totalTime: number;
+};
+
+export function TimerDisplay({ timeLeft, totalTime }: TimerDisplayProps) {
+  const t = useTranslations("quiz");
+
+  const size = 80;
+  const strokeWidth = 6;
+  const radius = (size - strokeWidth) / 2;
+  const circumference = 2 * Math.PI * radius;
+  const fraction = totalTime > 0 ? timeLeft / totalTime : 0;
+  const dashOffset = circumference * (1 - fraction);
+
+  // Color transitions based on remaining time fraction
+  let ringColor: string;
+  let textColor: string;
+  if (fraction > 0.5) {
+    ringColor = "stroke-primary";
+    textColor = "text-primary";
+  } else if (fraction > 0.25) {
+    ringColor = "stroke-tertiary";
+    textColor = "text-tertiary";
+  } else {
+    ringColor = "stroke-error";
+    textColor = "text-error";
+  }
+
+  return (
+    <div className="flex flex-col items-center gap-1">
+      <div className="relative" style={{ width: size, height: size }}>
+        <svg
+          width={size}
+          height={size}
+          className="-rotate-90"
+          aria-hidden="true"
+        >
+          {/* Track */}
+          <circle
+            cx={size / 2}
+            cy={size / 2}
+            r={radius}
+            fill="none"
+            strokeWidth={strokeWidth}
+            className="stroke-surface-container-highest"
+          />
+          {/* Progress ring */}
+          <circle
+            cx={size / 2}
+            cy={size / 2}
+            r={radius}
+            fill="none"
+            strokeWidth={strokeWidth}
+            strokeLinecap="round"
+            strokeDasharray={circumference}
+            strokeDashoffset={dashOffset}
+            className={`${ringColor} transition-all duration-500`}
+          />
+        </svg>
+        {/* Seconds label */}
+        <div className="absolute inset-0 flex items-center justify-center">
+          <span className={`text-xl font-extrabold leading-none ${textColor}`}>
+            {timeLeft}s
+          </span>
+        </div>
+      </div>
+      <span className="text-xs font-bold uppercase tracking-widest text-on-surface-variant">
+        {t("timeLeft")}
+      </span>
+    </div>
+  );
+}

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -6,6 +6,8 @@ export type Continent =
   | "South America"
   | "Oceania";
 
+export type Difficulty = "easy" | "normal" | "hard";
+
 export type Locale = "en" | "es";
 
 export type FunFact = {

--- a/src/lib/hooks/useGameState.ts
+++ b/src/lib/hooks/useGameState.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { Country, Continent, Difficulty } from "@/data/types";
 import { generateQuestion, QuizQuestion } from "@/lib/utils/quiz";
 import { filterByContinent } from "@/lib/utils/countries";
@@ -54,10 +54,10 @@ export function useGameState(
 ) {
   const [state, setState] = useState<GameState>(createInitialState);
 
-  const filteredPool = continent ? filterByContinent(pool, continent) : pool;
-  // Keep a ref so effects always have the latest pool without being dependencies
-  const filteredPoolRef = useRef(filteredPool);
-  filteredPoolRef.current = filteredPool;
+  const filteredPool = useMemo(
+    () => (continent ? filterByContinent(pool, continent) : pool),
+    [pool, continent],
+  );
 
   const selectDifficulty = useCallback((difficulty: Difficulty) => {
     setState((prev) => {
@@ -68,7 +68,7 @@ export function useGameState(
 
   const startGame = useCallback(() => {
     setState((prev) => {
-      const question = generateQuestion(filteredPoolRef.current);
+      const question = generateQuestion(filteredPool);
       return {
         ...createInitialState(),
         difficulty: prev.difficulty,
@@ -78,7 +78,7 @@ export function useGameState(
         timeLeft: TIMER_DURATIONS[prev.difficulty],
       };
     });
-  }, []);
+  }, [filteredPool]);
 
   const submitAnswer = useCallback((slug: string) => {
     setState((prev) => {
@@ -107,9 +107,12 @@ export function useGameState(
     });
   }, []);
 
+  // Destructure stable primitives for use as effect dependencies
+  const { status, timeLeft } = state;
+
   // Countdown: decrement timeLeft by 1 every second while playing
   useEffect(() => {
-    if (state.status !== "playing" || state.timeLeft === null || state.timeLeft <= 0) return;
+    if (status !== "playing" || timeLeft === null || timeLeft <= 0) return;
 
     const timer = setTimeout(() => {
       setState((prev) => {
@@ -119,26 +122,30 @@ export function useGameState(
     }, 1000);
 
     return () => clearTimeout(timer);
-  }, [state.status, state.timeLeft]);
+  }, [status, timeLeft]);
 
   // Timeout: when timeLeft reaches 0 while still playing, treat as a wrong answer
   useEffect(() => {
-    if (state.status !== "playing" || state.timeLeft !== 0) return;
+    if (status !== "playing" || timeLeft !== 0) return;
 
-    setState((prev) => {
-      if (prev.status !== "playing" || prev.timeLeft !== 0) return prev;
-      const newLives = prev.lives - 1;
-      return {
-        ...prev,
-        status: newLives <= 0 ? "gameOver" : "timeout",
-        lives: newLives,
-      };
-    });
-  }, [state.status, state.timeLeft]);
+    // Defer setState to avoid synchronous state update within an effect
+    const timer = setTimeout(() => {
+      setState((prev) => {
+        if (prev.status !== "playing" || prev.timeLeft !== 0) return prev;
+        const newLives = prev.lives - 1;
+        return {
+          ...prev,
+          status: newLives <= 0 ? "gameOver" : "timeout",
+          lives: newLives,
+        };
+      });
+    }, 0);
+
+    return () => clearTimeout(timer);
+  }, [status, timeLeft]);
 
   // Auto-advance: move to next question 500ms after answer feedback
   useEffect(() => {
-    const { status } = state;
     if (status !== "correct" && status !== "wrong" && status !== "timeout") return;
 
     const timer = setTimeout(() => {
@@ -147,7 +154,7 @@ export function useGameState(
           return prev;
         }
 
-        const question = generateQuestion(filteredPoolRef.current, prev.usedSlugs);
+        const question = generateQuestion(filteredPool, prev.usedSlugs);
         if (!question) return { ...prev, status: "gameOver" };
 
         return {
@@ -163,7 +170,7 @@ export function useGameState(
     }, 500);
 
     return () => clearTimeout(timer);
-  }, [state.status]);
+  }, [status, filteredPool]);
 
   return {
     state,

--- a/src/lib/hooks/useGameState.ts
+++ b/src/lib/hooks/useGameState.ts
@@ -1,7 +1,7 @@
 "use client";
 
-import { useCallback, useState } from "react";
-import { Country, Continent } from "@/data/types";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Country, Continent, Difficulty } from "@/data/types";
 import { generateQuestion, QuizQuestion } from "@/lib/utils/quiz";
 import { filterByContinent } from "@/lib/utils/countries";
 
@@ -10,30 +10,41 @@ export type GameStatus =
   | "playing"
   | "correct"
   | "wrong"
+  | "timeout"
   | "gameOver";
 
 export type GameState = {
   status: GameStatus;
+  difficulty: Difficulty;
   score: number;
   lives: number;
   questionIndex: number;
   selectedAnswer: string | null;
   currentQuestion: QuizQuestion | null;
   usedSlugs: string[];
+  timeLeft: number | null;
 };
 
 const INITIAL_LIVES = 3;
 const POINTS_PER_CORRECT = 100;
 
+export const TIMER_DURATIONS: Record<Difficulty, number | null> = {
+  easy: null,
+  normal: 5,
+  hard: 3,
+};
+
 function createInitialState(): GameState {
   return {
     status: "idle",
+    difficulty: "normal",
     score: 0,
     lives: INITIAL_LIVES,
     questionIndex: 0,
     selectedAnswer: null,
     currentQuestion: null,
     usedSlugs: [],
+    timeLeft: null,
   };
 }
 
@@ -43,72 +54,121 @@ export function useGameState(
 ) {
   const [state, setState] = useState<GameState>(createInitialState);
 
-  const filteredPool =
-    continent ? filterByContinent(pool, continent) : pool;
+  const filteredPool = continent ? filterByContinent(pool, continent) : pool;
+  // Keep a ref so effects always have the latest pool without being dependencies
+  const filteredPoolRef = useRef(filteredPool);
+  filteredPoolRef.current = filteredPool;
+
+  const selectDifficulty = useCallback((difficulty: Difficulty) => {
+    setState((prev) => {
+      if (prev.status !== "idle") return prev;
+      return { ...prev, difficulty };
+    });
+  }, []);
 
   const startGame = useCallback(() => {
-    const question = generateQuestion(filteredPool);
-    setState({
-      ...createInitialState(),
-      status: "playing",
-      currentQuestion: question,
-      usedSlugs: question ? [question.correct.slug] : [],
-    });
-  }, [filteredPool]);
-
-  const submitAnswer = useCallback(
-    (slug: string) => {
-      setState((prev) => {
-        if (prev.status !== "playing" || !prev.currentQuestion) return prev;
-
-        const isCorrect = slug === prev.currentQuestion.correct.slug;
-
-        if (isCorrect) {
-          return {
-            ...prev,
-            status: "correct",
-            score: prev.score + POINTS_PER_CORRECT,
-            selectedAnswer: slug,
-          };
-        }
-
-        const newLives = prev.lives - 1;
-        return {
-          ...prev,
-          status: newLives <= 0 ? "gameOver" : "wrong",
-          lives: newLives,
-          selectedAnswer: slug,
-        };
-      });
-    },
-    [],
-  );
-
-  const nextQuestion = useCallback(() => {
     setState((prev) => {
-      if (prev.status !== "correct" && prev.status !== "wrong") return prev;
-
-      const question = generateQuestion(filteredPool, prev.usedSlugs);
-
-      if (!question) {
-        return { ...prev, status: "gameOver" };
-      }
-
+      const question = generateQuestion(filteredPoolRef.current);
       return {
-        ...prev,
+        ...createInitialState(),
+        difficulty: prev.difficulty,
         status: "playing",
-        questionIndex: prev.questionIndex + 1,
-        selectedAnswer: null,
         currentQuestion: question,
-        usedSlugs: [...prev.usedSlugs, question.correct.slug],
+        usedSlugs: question ? [question.correct.slug] : [],
+        timeLeft: TIMER_DURATIONS[prev.difficulty],
       };
     });
-  }, [filteredPool]);
+  }, []);
+
+  const submitAnswer = useCallback((slug: string) => {
+    setState((prev) => {
+      if (prev.status !== "playing" || !prev.currentQuestion) return prev;
+
+      const isCorrect = slug === prev.currentQuestion.correct.slug;
+
+      if (isCorrect) {
+        return {
+          ...prev,
+          status: "correct",
+          score: prev.score + POINTS_PER_CORRECT,
+          selectedAnswer: slug,
+          timeLeft: null,
+        };
+      }
+
+      const newLives = prev.lives - 1;
+      return {
+        ...prev,
+        status: newLives <= 0 ? "gameOver" : "wrong",
+        lives: newLives,
+        selectedAnswer: slug,
+        timeLeft: null,
+      };
+    });
+  }, []);
+
+  // Countdown: decrement timeLeft by 1 every second while playing
+  useEffect(() => {
+    if (state.status !== "playing" || state.timeLeft === null || state.timeLeft <= 0) return;
+
+    const timer = setTimeout(() => {
+      setState((prev) => {
+        if (prev.status !== "playing" || prev.timeLeft === null || prev.timeLeft <= 0) return prev;
+        return { ...prev, timeLeft: prev.timeLeft - 1 };
+      });
+    }, 1000);
+
+    return () => clearTimeout(timer);
+  }, [state.status, state.timeLeft]);
+
+  // Timeout: when timeLeft reaches 0 while still playing, treat as a wrong answer
+  useEffect(() => {
+    if (state.status !== "playing" || state.timeLeft !== 0) return;
+
+    setState((prev) => {
+      if (prev.status !== "playing" || prev.timeLeft !== 0) return prev;
+      const newLives = prev.lives - 1;
+      return {
+        ...prev,
+        status: newLives <= 0 ? "gameOver" : "timeout",
+        lives: newLives,
+      };
+    });
+  }, [state.status, state.timeLeft]);
+
+  // Auto-advance: move to next question 500ms after answer feedback
+  useEffect(() => {
+    const { status } = state;
+    if (status !== "correct" && status !== "wrong" && status !== "timeout") return;
+
+    const timer = setTimeout(() => {
+      setState((prev) => {
+        if (prev.status !== "correct" && prev.status !== "wrong" && prev.status !== "timeout") {
+          return prev;
+        }
+
+        const question = generateQuestion(filteredPoolRef.current, prev.usedSlugs);
+        if (!question) return { ...prev, status: "gameOver" };
+
+        return {
+          ...prev,
+          status: "playing",
+          questionIndex: prev.questionIndex + 1,
+          selectedAnswer: null,
+          currentQuestion: question,
+          usedSlugs: [...prev.usedSlugs, question.correct.slug],
+          timeLeft: TIMER_DURATIONS[prev.difficulty],
+        };
+      });
+    }, 500);
+
+    return () => clearTimeout(timer);
+  }, [state.status]);
 
   return {
     state,
+    selectDifficulty,
     startGame,
     submitAnswer,
-    nextQuestion,
   };
 }


### PR DESCRIPTION
Closes #30

## Summary
- **Difficulty picker** (Easy / Normal / Hard) shown on the idle screen before the game starts
- **Per-question countdown timer** — Easy: no timer, Normal: 5 s, Hard: 3 s — rendered as an SVG circular ring (`TimerDisplay`)
- **Auto-advance** replaces the "Next" button — moves to the next question 500 ms after correct, wrong, or timeout feedback
- **Timeout handling** — when the clock hits 0 it deducts a life, highlights the correct answer, then auto-advances
- i18n keys updated in `en.json` / `es.json`; `nextQuestion` and `hintTitle` keys removed

## Test Plan
- [x] 61/61 unit tests passing (`npm test`)
- [x] 0 lint errors (`npm run lint`)
- [x] Clean production build (`npm run build`)