### PR TITLE
feat(nav): region click on Home navigates to Catalog; hide sidebar on Games

### DIFF
--- a/src/app/[locale]/games/guess-the-flag/GameContent.tsx
+++ b/src/app/[locale]/games/guess-the-flag/GameContent.tsx
@@ -1,9 +1,7 @@
 "use client";
 
-import { useMemo, useCallback } from "react";
+import { useCallback } from "react";
 import { useCountries } from "@/lib/providers/CountriesProvider";
-import { filterByContinent } from "@/lib/utils/countries";
-import { useContinentFilter } from "@/lib/hooks/useContinentFilter";
 import { useUserProgress } from "@/lib/hooks/useUserProgress";
 import { AppShell } from "@/components/layout/AppShell";
 import { FlagQuiz } from "@/components/games/FlagQuiz";
@@ -11,13 +9,7 @@ import type { InsigniaId } from "@/data/types";
 
 export function GameContent() {
   const { countries } = useCountries();
-  const { activeContinent } = useContinentFilter();
   const { saveQuizResult } = useUserProgress();
-
-  const pool = useMemo(
-    () => filterByContinent(countries, activeContinent),
-    [countries, activeContinent],
-  );
 
   const handleGameOver = useCallback(
     (score: number, insignias: InsigniaId[], correctInGame: number) => {
@@ -27,9 +19,9 @@ export function GameContent() {
   );
 
   return (
-    <AppShell>
+    <AppShell showSidebar={false}>
       <div className="max-w-4xl mx-auto">
-        <FlagQuiz pool={pool} onGameOver={handleGameOver} />
+        <FlagQuiz pool={countries} onGameOver={handleGameOver} />
       </div>
     </AppShell>
   );

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -2,8 +2,9 @@
 
 import { useMemo, Suspense } from "react";
 import { useTranslations } from "next-intl";
-import { Link } from "@/i18n/navigation";
+import { Link, useRouter } from "@/i18n/navigation";
 import { AppShell } from "@/components/layout/AppShell";
+import { Continent } from "@/data/types";
 import { Button } from "@/components/ui/Button";
 import { useCountries } from "@/lib/providers/CountriesProvider";
 import { useAuth } from "@/lib/providers/AuthProvider";
@@ -18,6 +19,11 @@ function DashboardContent() {
   const t = useTranslations("home");
   const { countries } = useCountries();
   const { progress, isAnonymous, nickname } = useAuth();
+  const router = useRouter();
+
+  const handleContinentSelect = (continent: Continent | null) => {
+    if (continent) router.push(`/catalog?continent=${continent}`);
+  };
 
   // Pick 4 countries daily — deterministic based on day-of-year (DAY_OF_YEAR computed at module load)
   const dailyCountries = useMemo(() => {
@@ -27,7 +33,7 @@ function DashboardContent() {
   }, [countries]);
 
   return (
-    <AppShell showSidebar>
+    <AppShell showSidebar onContinentSelect={handleContinentSelect}>
       <section className="space-y-12">
         {/* Welcome Header */}
         <header className="space-y-4">

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -5,12 +5,14 @@ import { TopNav } from "./TopNav";
 import { SideNav } from "./SideNav";
 import { BottomNav } from "./BottomNav";
 import { useContinentFilter } from "@/lib/hooks/useContinentFilter";
+import { Continent } from "@/data/types";
 
 type AppShellProps = {
   children: ReactNode;
   showSidebar?: boolean;
   searchQuery?: string;
   onSearchChange?: (value: string) => void;
+  onContinentSelect?: (continent: Continent | null) => void;
 };
 
 function AppShellInner({
@@ -18,8 +20,11 @@ function AppShellInner({
   showSidebar = true,
   searchQuery,
   onSearchChange,
+  onContinentSelect,
 }: AppShellProps) {
   const { activeContinent, setContinent } = useContinentFilter();
+
+  const handleContinentSelect = onContinentSelect ?? setContinent;
 
   return (
     <div className="min-h-screen bg-surface">
@@ -28,7 +33,7 @@ function AppShellInner({
         {showSidebar && (
           <SideNav
             activeContinent={activeContinent}
-            onSelectContinent={setContinent}
+            onSelectContinent={handleContinentSelect}
           />
         )}
         <main className="flex-1 p-6 md:p-12 pb-24 lg:pb-12">


### PR DESCRIPTION
## Summary

Fixes two sidebar UX issues:

### 1. Home → Catalog region navigation
Clicking a region in the left sidebar while on the Home/Dashboard view now navigates to the Catalog pre-filtered to that region (e.g. `/en/catalog?continent=Europe`). Previously, the click set `?continent=` on the home URL which had no visible effect.

**Implementation:** Added `onContinentSelect` override prop to `AppShell`. The Home page passes a handler that calls `router.push('/catalog?continent=...')` — using next-intl's locale-aware router.

### 2. Games sidebar hidden
The left sidebar no longer appears on the Games (Guess the Flag) page — it added no value mid-game. Continent-based pool filtering is also removed since there's no longer a UI control for it; the quiz uses all 195 countries.

## Files changed
- `src/components/layout/AppShell.tsx` — add `onContinentSelect` prop
- `src/app/[locale]/page.tsx` — add navigation handler
- `src/app/[locale]/games/guess-the-flag/GameContent.tsx` — hide sidebar, use full pool

## Verification
- ✅ 90/90 tests pass
- ✅ Production build succeeds
- ✅ Catalog region filtering unchanged

Closes #35