### PR TITLE
feat(map): globe polish & UX improvements

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -65,7 +65,8 @@
     "regionalContext": "Regional Context",
     "exploreRegion": "Explore Region",
     "flagAlt": "Flag of {name}",
-    "backToCatalog": "Back to Catalog"
+    "backToCatalog": "Back to Catalog",
+    "backToMap": "Back to Map"
   },
   "quiz": {
     "title": "Guess the Flag!",
@@ -194,6 +195,14 @@
     "pauseRotation": "Pause rotation",
     "resumeRotation": "Resume rotation",
     "markExplored": "Mark as Explored",
-    "alreadyExplored": "Already Explored"
+    "alreadyExplored": "Already Explored",
+    "toggleMode": "Toggle map mode",
+    "realisticMode": "Switch to realistic",
+    "politicalMode": "Switch to political",
+    "enableHoverPreview": "Enable hover preview",
+    "disableHoverPreview": "Disable hover preview",
+    "geolocate": "Find my location",
+    "reset": "Reset view",
+    "geolocationError": "Could not detect your location"
   }
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -65,7 +65,8 @@
     "regionalContext": "Contexto Regional",
     "exploreRegion": "Explorar Región",
     "flagAlt": "Bandera de {name}",
-    "backToCatalog": "Volver al Catálogo"
+    "backToCatalog": "Volver al Catálogo",
+    "backToMap": "Volver al Mapa"
   },
   "quiz": {
     "title": "¡Adivina la Bandera!",
@@ -194,6 +195,14 @@
     "pauseRotation": "Pausar rotación",
     "resumeRotation": "Reanudar rotación",
     "markExplored": "Marcar como Explorado",
-    "alreadyExplored": "Ya Explorado"
+    "alreadyExplored": "Ya Explorado",
+    "toggleMode": "Alternar modo de mapa",
+    "realisticMode": "Cambiar a realista",
+    "politicalMode": "Cambiar a político",
+    "enableHoverPreview": "Activar vista previa al pasar",
+    "disableHoverPreview": "Desactivar vista previa al pasar",
+    "geolocate": "Encontrar mi ubicación",
+    "reset": "Restablecer vista",
+    "geolocationError": "No se pudo detectar tu ubicación"
   }
 }

--- a/src/app/[locale]/catalog/[countrySlug]/page.tsx
+++ b/src/app/[locale]/catalog/[countrySlug]/page.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from "react";
 import { setRequestLocale } from "next-intl/server";
 import { getCountryBySlug, getCountrySlugs } from "@/lib/utils/countries";
 import { CountryDetailHeader } from "@/components/country/CountryDetailHeader";
@@ -34,7 +35,9 @@ export default async function CountryDetailPage({
 
   return (
     <div className="min-h-screen bg-surface">
-      <CountryDetailHeader />
+      <Suspense fallback={null}>
+        <CountryDetailHeader />
+      </Suspense>
       <CountryDetailContent slug={countrySlug} />
     </div>
   );

--- a/src/app/[locale]/map/page.tsx
+++ b/src/app/[locale]/map/page.tsx
@@ -12,7 +12,7 @@ function MapContent() {
   return (
     <div className="relative h-screen overflow-hidden bg-[#0A0E27]">
       <div className="absolute inset-x-0 top-0 z-20">
-        <TopNav />
+        <TopNav transparent />
       </div>
       {loading ? (
         <div className="flex h-full items-center justify-center">

--- a/src/components/country/CountryDetailHeader.tsx
+++ b/src/components/country/CountryDetailHeader.tsx
@@ -2,21 +2,34 @@
 
 import { useTranslations } from "next-intl";
 import { Link } from "@/i18n/navigation";
+import { useSearchParams } from "next/navigation";
 
 export function CountryDetailHeader() {
   const t = useTranslations("country");
   const tNav = useTranslations("nav");
+  const searchParams = useSearchParams();
+  const from = searchParams.get("from");
 
   return (
     <header className="glass sticky top-0 z-40">
       <div className="flex items-center gap-6 px-8 py-4 max-w-screen-xl mx-auto">
-        <Link
-          href="/catalog"
-          className="flex items-center gap-2 text-on-surface-variant hover:text-primary transition-bounce group"
-        >
-          <span className="material-symbols-outlined">arrow_back</span>
-          <span className="font-bold">{t("backToCatalog")}</span>
-        </Link>
+        {from === "map" ? (
+          <Link
+            href="/map"
+            className="flex items-center gap-2 text-on-surface-variant hover:text-primary transition-bounce group"
+          >
+            <span className="material-symbols-outlined">arrow_back</span>
+            <span className="font-bold">{t("backToMap")}</span>
+          </Link>
+        ) : (
+          <Link
+            href="/catalog"
+            className="flex items-center gap-2 text-on-surface-variant hover:text-primary transition-bounce group"
+          >
+            <span className="material-symbols-outlined">arrow_back</span>
+            <span className="font-bold">{t("backToCatalog")}</span>
+          </Link>
+        )}
         <span className="text-2xl font-extrabold text-primary tracking-tight">
           {tNav("title")}
         </span>

--- a/src/components/layout/TopNav.tsx
+++ b/src/components/layout/TopNav.tsx
@@ -12,9 +12,10 @@ import { ProfileDialog } from "@/components/auth/ProfileDialog";
 type TopNavProps = {
   searchQuery?: string;
   onSearchChange?: (value: string) => void;
+  transparent?: boolean;
 };
 
-export function TopNav({ searchQuery, onSearchChange }: TopNavProps) {
+export function TopNav({ searchQuery, onSearchChange, transparent = false }: TopNavProps) {
   const t = useTranslations("nav");
   const tSearch = useTranslations("search");
   const tAuth = useTranslations("auth");
@@ -33,11 +34,19 @@ export function TopNav({ searchQuery, onSearchChange }: TopNavProps) {
 
   return (
     <>
-      <header className="glass sticky top-0 z-40">
+      <header
+        className={
+          transparent
+            ? "bg-transparent backdrop-blur-md shadow-[0_2px_20px_rgba(0,0,0,0.4)] sticky top-0 z-40"
+            : "glass sticky top-0 z-40"
+        }
+      >
         <div className="flex justify-between items-center w-full px-8 py-4 max-w-screen-2xl mx-auto">
           <Link
             href="/"
-            className="text-2xl font-extrabold text-primary tracking-tight"
+            className={`text-2xl font-extrabold tracking-tight ${
+              transparent ? "text-white" : "text-primary"
+            }`}
           >
             {t("title")}
           </Link>
@@ -55,9 +64,13 @@ export function TopNav({ searchQuery, onSearchChange }: TopNavProps) {
                   className={`
                     font-bold text-lg transition-bounce
                     ${
-                      isActive
-                        ? "text-primary border-b-4 border-primary"
-                        : "text-on-surface-variant hover:text-on-surface hover:scale-105"
+                      transparent
+                        ? isActive
+                          ? "text-white border-b-4 border-white"
+                          : "text-white/70 hover:text-white hover:scale-105"
+                        : isActive
+                          ? "text-primary border-b-4 border-primary"
+                          : "text-on-surface-variant hover:text-on-surface hover:scale-105"
                     }
                   `}
                 >

--- a/src/components/map/CountryLabels.tsx
+++ b/src/components/map/CountryLabels.tsx
@@ -1,16 +1,18 @@
-import { useMemo } from "react";
+import { useMemo, type RefObject } from "react";
 import { Html } from "@react-three/drei";
 import type { ProcessedCountry } from "@/lib/hooks/useGlobeData";
 import { countriesData } from "@/data/countries";
 import type { Locale } from "@/data/types";
+import type * as THREE from "three";
 
 type CountryLabelsProps = {
   countries: ProcessedCountry[];
   visible: boolean;
   locale: Locale;
+  sphereRef: RefObject<THREE.Mesh | null>;
 };
 
-export function CountryLabels({ countries, visible, locale }: CountryLabelsProps) {
+export function CountryLabels({ countries, visible, locale, sphereRef }: CountryLabelsProps) {
 
   const nameBySlug = useMemo(
     () => new Map(countriesData.map((c) => [c.slug, c.translations[locale].name])),
@@ -26,12 +28,12 @@ export function CountryLabels({ countries, visible, locale }: CountryLabelsProps
           key={c.slug}
           position={c.centroid}
           center
-          distanceFactor={6}
           sprite
           zIndexRange={[0, 0]}
+          occlude={[sphereRef as RefObject<THREE.Object3D>]}
         >
           <span
-            className="pointer-events-none whitespace-nowrap text-[10px] font-bold text-white"
+            className="pointer-events-none select-none whitespace-nowrap text-[10px] font-bold text-white"
             style={{ textShadow: "0 1px 3px rgba(0,0,0,0.8)" }}
           >
             {nameBySlug.get(c.slug) ?? c.slug}

--- a/src/components/map/CountryMeshes.tsx
+++ b/src/components/map/CountryMeshes.tsx
@@ -18,12 +18,14 @@ type CountryMeshesProps = {
   countries: ProcessedCountry[];
   discoveredSlugs: string[];
   onCountrySelect?: (slug: string) => void;
+  mode: "realistic" | "political";
 };
 
 export function CountryMeshes({
   countries,
   discoveredSlugs,
   onCountrySelect,
+  mode,
 }: CountryMeshesProps) {
   const handlePointerOver = (e: ThreeEvent<PointerEvent>) => {
     e.stopPropagation();
@@ -58,10 +60,12 @@ export function CountryMeshes({
               onCountrySelect?.(country.slug);
             }}
           >
-            <meshStandardMaterial
+          <meshStandardMaterial
               color={color}
               roughness={0.6}
               metalness={0.1}
+              transparent={mode === "realistic"}
+              opacity={mode === "realistic" ? 0 : 1}
             />
           </mesh>
         );

--- a/src/components/map/CountryMeshes.tsx
+++ b/src/components/map/CountryMeshes.tsx
@@ -19,6 +19,8 @@ type CountryMeshesProps = {
   discoveredSlugs: string[];
   onCountrySelect?: (slug: string) => void;
   mode: "realistic" | "political";
+  hoverMode: boolean;
+  onCountryHover?: (slug: string | null) => void;
 };
 
 export function CountryMeshes({
@@ -26,18 +28,22 @@ export function CountryMeshes({
   discoveredSlugs,
   onCountrySelect,
   mode,
+  hoverMode,
+  onCountryHover,
 }: CountryMeshesProps) {
-  const handlePointerOver = (e: ThreeEvent<PointerEvent>) => {
+  const handlePointerOver = (e: ThreeEvent<PointerEvent>, slug: string) => {
     e.stopPropagation();
     const mat = (e.object as THREE.Mesh).material as THREE.MeshStandardMaterial;
     mat.emissive.set("#333333");
     document.body.style.cursor = "pointer";
+    if (hoverMode) onCountryHover?.(slug);
   };
 
   const handlePointerOut = (e: ThreeEvent<PointerEvent>) => {
     const mat = (e.object as THREE.Mesh).material as THREE.MeshStandardMaterial;
     mat.emissive.set("#000000");
     document.body.style.cursor = "default";
+    if (hoverMode) onCountryHover?.(null);
   };
 
   return (
@@ -53,7 +59,7 @@ export function CountryMeshes({
             key={country.slug}
             geometry={country.geometry}
             userData={{ slug: country.slug }}
-            onPointerOver={handlePointerOver}
+            onPointerOver={(e) => handlePointerOver(e, country.slug)}
             onPointerOut={handlePointerOut}
             onClick={(e) => {
               e.stopPropagation();

--- a/src/components/map/CountryPopup.tsx
+++ b/src/components/map/CountryPopup.tsx
@@ -130,7 +130,7 @@ export function CountryPopup({
 
         {/* Explore link */}
         <a
-          href={`/${locale}/catalog/${slug}`}
+          href={`/${locale}/catalog/${slug}?from=map`}
           className="mt-3 block w-full rounded-xl bg-white/10 py-2 text-center text-sm font-medium transition-colors hover:bg-white/20"
         >
           {exploreLabel}

--- a/src/components/map/Globe.tsx
+++ b/src/components/map/Globe.tsx
@@ -25,6 +25,7 @@ export function Globe({ discoveredSlugs, onCountrySelect, discoverCountry }: Glo
   const [autoRotate, setAutoRotate] = useState(true);
   const targetZRef = useRef<number>(2.5);
   const cameraRef = useRef<RootState["camera"] | null>(null);
+  const closePopupRef = useRef<(() => void) | null>(null);
   const locale = useLocale() as Locale;
   const t = useTranslations("globe");
 
@@ -80,6 +81,7 @@ export function Globe({ discoveredSlugs, onCountrySelect, discoverCountry }: Glo
         dpr={[1, 2]}
         style={{ background: "#0A0E27" }}
         onCreated={handleCreated}
+        onPointerMissed={() => closePopupRef.current?.()}
       >
         <Suspense fallback={null}>
           <GlobeScene
@@ -97,6 +99,7 @@ export function Globe({ discoveredSlugs, onCountrySelect, discoverCountry }: Glo
             isDaylight={isDaylight}
             autoRotate={autoRotate}
             discoverCountry={discoverCountry}
+            closePopupRef={closePopupRef}
           />
         </Suspense>
       </Canvas>

--- a/src/components/map/Globe.tsx
+++ b/src/components/map/Globe.tsx
@@ -25,6 +25,9 @@ export function Globe({ discoveredSlugs, onCountrySelect, discoverCountry }: Glo
   const [autoRotate, setAutoRotate] = useState(true);
   const [globeMode, setGlobeMode] = useState<"realistic" | "political">("political");
   const [hoverMode, setHoverMode] = useState(false);
+  const [geolocating, setGeolocating] = useState(false);
+  const [geoError, setGeoError] = useState<string | null>(null);
+  const geoErrorTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const targetZRef = useRef<number>(2.5);
   const cameraRef = useRef<RootState["camera"] | null>(null);
   const closePopupRef = useRef<(() => void) | null>(null);
@@ -44,6 +47,39 @@ export function Globe({ discoveredSlugs, onCountrySelect, discoverCountry }: Glo
     if (cameraRef.current) {
       cameraRef.current.position.set(0, 0, 2.5);
     }
+  };
+
+  const handleGeolocate = () => {
+    if (!navigator.geolocation) {
+      if (geoErrorTimer.current) clearTimeout(geoErrorTimer.current);
+      setGeoError(t("geolocationError"));
+      geoErrorTimer.current = setTimeout(() => setGeoError(null), 3000);
+      return;
+    }
+    setGeolocating(true);
+    navigator.geolocation.getCurrentPosition(
+      (pos) => {
+        const lat = pos.coords.latitude;
+        const lng = pos.coords.longitude;
+        const r = 2.0;
+        const phi = (90 - lat) * (Math.PI / 180);
+        const theta = (lng + 180) * (Math.PI / 180);
+        const x = -r * Math.sin(phi) * Math.cos(theta);
+        const y = r * Math.cos(phi);
+        const z = r * Math.sin(phi) * Math.sin(theta);
+        if (cameraRef.current) {
+          cameraRef.current.position.set(x, y, z);
+          targetZRef.current = r;
+        }
+        setGeolocating(false);
+      },
+      () => {
+        if (geoErrorTimer.current) clearTimeout(geoErrorTimer.current);
+        setGeoError(t("geolocationError"));
+        geoErrorTimer.current = setTimeout(() => setGeoError(null), 3000);
+        setGeolocating(false);
+      },
+    );
   };
 
   const handleCreated = (state: RootState) => {
@@ -121,7 +157,14 @@ export function Globe({ discoveredSlugs, onCountrySelect, discoverCountry }: Glo
         onToggleMode={() => setGlobeMode((m) => m === "realistic" ? "political" : "realistic")}
         hoverMode={hoverMode}
         onToggleHoverMode={() => setHoverMode((v) => !v)}
+        onGeolocate={handleGeolocate}
+        geolocating={geolocating}
       />
+      {geoError && (
+        <div className="absolute bottom-8 left-1/2 -translate-x-1/2 bg-black/70 text-white text-sm px-4 py-2 rounded-xl backdrop-blur-md pointer-events-none">
+          {geoError}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/map/Globe.tsx
+++ b/src/components/map/Globe.tsx
@@ -23,6 +23,7 @@ export function Globe({ discoveredSlugs, onCountrySelect, discoverCountry }: Glo
   const [showLabels, setShowLabels] = useState(false);
   const [isDaylight, setIsDaylight] = useState(false);
   const [autoRotate, setAutoRotate] = useState(true);
+  const [globeMode, setGlobeMode] = useState<"realistic" | "political">("political");
   const targetZRef = useRef<number>(2.5);
   const cameraRef = useRef<RootState["camera"] | null>(null);
   const closePopupRef = useRef<(() => void) | null>(null);
@@ -100,6 +101,7 @@ export function Globe({ discoveredSlugs, onCountrySelect, discoverCountry }: Glo
             autoRotate={autoRotate}
             discoverCountry={discoverCountry}
             closePopupRef={closePopupRef}
+            globeMode={globeMode}
           />
         </Suspense>
       </Canvas>
@@ -113,6 +115,8 @@ export function Globe({ discoveredSlugs, onCountrySelect, discoverCountry }: Glo
         onToggleRotate={() => setAutoRotate((v) => !v)}
         isDaylight={isDaylight}
         onToggleDaylight={() => setIsDaylight((v) => !v)}
+        globeMode={globeMode}
+        onToggleMode={() => setGlobeMode((m) => m === "realistic" ? "political" : "realistic")}
       />
     </div>
   );

--- a/src/components/map/Globe.tsx
+++ b/src/components/map/Globe.tsx
@@ -24,6 +24,7 @@ export function Globe({ discoveredSlugs, onCountrySelect, discoverCountry }: Glo
   const [isDaylight, setIsDaylight] = useState(false);
   const [autoRotate, setAutoRotate] = useState(true);
   const [globeMode, setGlobeMode] = useState<"realistic" | "political">("political");
+  const [hoverMode, setHoverMode] = useState(false);
   const targetZRef = useRef<number>(2.5);
   const cameraRef = useRef<RootState["camera"] | null>(null);
   const closePopupRef = useRef<(() => void) | null>(null);
@@ -102,6 +103,7 @@ export function Globe({ discoveredSlugs, onCountrySelect, discoverCountry }: Glo
             discoverCountry={discoverCountry}
             closePopupRef={closePopupRef}
             globeMode={globeMode}
+            hoverMode={hoverMode}
           />
         </Suspense>
       </Canvas>
@@ -117,6 +119,8 @@ export function Globe({ discoveredSlugs, onCountrySelect, discoverCountry }: Glo
         onToggleDaylight={() => setIsDaylight((v) => !v)}
         globeMode={globeMode}
         onToggleMode={() => setGlobeMode((m) => m === "realistic" ? "political" : "realistic")}
+        hoverMode={hoverMode}
+        onToggleHoverMode={() => setHoverMode((v) => !v)}
       />
     </div>
   );

--- a/src/components/map/Globe.tsx
+++ b/src/components/map/Globe.tsx
@@ -23,14 +23,25 @@ export function Globe({ discoveredSlugs, onCountrySelect, discoverCountry }: Glo
   const [showLabels, setShowLabels] = useState(false);
   const [isDaylight, setIsDaylight] = useState(false);
   const [autoRotate, setAutoRotate] = useState(true);
-  const zoomRef = useRef<number>(0);
+  const targetZRef = useRef<number>(2.5);
   const cameraRef = useRef<RootState["camera"] | null>(null);
   const locale = useLocale() as Locale;
   const t = useTranslations("globe");
 
-  const handleZoomIn = () => { zoomRef.current = 1; };
-  const handleZoomOut = () => { zoomRef.current = -1; };
-  const handleReset = () => { zoomRef.current = 2; };
+  const handleZoomIn = () => {
+    const currentZ = cameraRef.current?.position.z ?? 2.5;
+    targetZRef.current = Math.max(currentZ - 0.5, 1.5);
+  };
+  const handleZoomOut = () => {
+    const currentZ = cameraRef.current?.position.z ?? 2.5;
+    targetZRef.current = Math.min(currentZ + 0.5, 4.0);
+  };
+  const handleReset = () => {
+    targetZRef.current = 2.5;
+    if (cameraRef.current) {
+      cameraRef.current.position.set(0, 0, 2.5);
+    }
+  };
 
   const handleCreated = (state: RootState) => {
     cameraRef.current = state.camera;
@@ -39,6 +50,7 @@ export function Globe({ discoveredSlugs, onCountrySelect, discoverCountry }: Glo
       if (saved) {
         const { x, y, z } = JSON.parse(saved);
         state.camera.position.set(x, y, z);
+        targetZRef.current = z;
       }
     } catch {
       // sessionStorage unavailable — ignore
@@ -74,7 +86,7 @@ export function Globe({ discoveredSlugs, onCountrySelect, discoverCountry }: Glo
             discoveredSlugs={discoveredSlugs}
             onCountrySelect={onCountrySelect}
             showLabels={showLabels}
-            zoomRef={zoomRef}
+            targetZRef={targetZRef}
             locale={locale}
             globeT={{
               capital: t("capital"),

--- a/src/components/map/GlobeControls.tsx
+++ b/src/components/map/GlobeControls.tsx
@@ -10,6 +10,8 @@ type GlobeControlsProps = {
   onToggleRotate: () => void;
   isDaylight: boolean;
   onToggleDaylight: () => void;
+  globeMode: "realistic" | "political";
+  onToggleMode: () => void;
 };
 
 export function GlobeControls({
@@ -22,6 +24,8 @@ export function GlobeControls({
   onToggleRotate,
   isDaylight,
   onToggleDaylight,
+  globeMode,
+  onToggleMode,
 }: GlobeControlsProps) {
   const t = useTranslations("globe");
   const btnBase =
@@ -29,6 +33,15 @@ export function GlobeControls({
 
   return (
     <div className="absolute bottom-8 right-8 z-10 flex flex-col gap-3">
+      <button
+        onClick={onToggleMode}
+        className={btnBase}
+        aria-label={globeMode === "realistic" ? t("politicalMode") : t("realisticMode")}
+      >
+        <span className="material-symbols-outlined">
+          {globeMode === "realistic" ? "map" : "satellite_alt"}
+        </span>
+      </button>
       <button
         onClick={onToggleDaylight}
         className={btnBase}

--- a/src/components/map/GlobeControls.tsx
+++ b/src/components/map/GlobeControls.tsx
@@ -14,6 +14,8 @@ type GlobeControlsProps = {
   onToggleMode: () => void;
   hoverMode: boolean;
   onToggleHoverMode: () => void;
+  onGeolocate: () => void;
+  geolocating: boolean;
 };
 
 export function GlobeControls({
@@ -30,6 +32,8 @@ export function GlobeControls({
   onToggleMode,
   hoverMode,
   onToggleHoverMode,
+  onGeolocate,
+  geolocating,
 }: GlobeControlsProps) {
   const t = useTranslations("globe");
   const btnBase =
@@ -90,8 +94,16 @@ export function GlobeControls({
       </button>
       <button
         onClick={onReset}
-        className="w-12 h-12 bg-indigo-500/80 text-white rounded-2xl shadow-lg flex items-center justify-center hover:bg-indigo-400/80 hover:scale-110 active:scale-95 transition-all duration-200"
-        aria-label={t("resetView")}
+        className={btnBase}
+        aria-label={t("reset")}
+      >
+        <span className="material-symbols-outlined">refresh</span>
+      </button>
+      <button
+        onClick={onGeolocate}
+        disabled={geolocating}
+        className={`w-12 h-12 bg-indigo-500/80 text-white rounded-2xl shadow-lg flex items-center justify-center hover:bg-indigo-400/80 hover:scale-110 active:scale-95 transition-all duration-200 disabled:opacity-60 disabled:cursor-not-allowed${geolocating ? " animate-pulse" : ""}`}
+        aria-label={t("geolocate")}
       >
         <span className="material-symbols-outlined">my_location</span>
       </button>

--- a/src/components/map/GlobeControls.tsx
+++ b/src/components/map/GlobeControls.tsx
@@ -12,6 +12,8 @@ type GlobeControlsProps = {
   onToggleDaylight: () => void;
   globeMode: "realistic" | "political";
   onToggleMode: () => void;
+  hoverMode: boolean;
+  onToggleHoverMode: () => void;
 };
 
 export function GlobeControls({
@@ -26,6 +28,8 @@ export function GlobeControls({
   onToggleDaylight,
   globeMode,
   onToggleMode,
+  hoverMode,
+  onToggleHoverMode,
 }: GlobeControlsProps) {
   const t = useTranslations("globe");
   const btnBase =
@@ -58,6 +62,15 @@ export function GlobeControls({
       >
         <span className="material-symbols-outlined">
           {autoRotate ? "pause_circle" : "play_circle"}
+        </span>
+      </button>
+      <button
+        onClick={onToggleHoverMode}
+        className={btnBase}
+        aria-label={hoverMode ? t("disableHoverPreview") : t("enableHoverPreview")}
+      >
+        <span className="material-symbols-outlined">
+          {hoverMode ? "mouse" : "touch_app"}
         </span>
       </button>
       <button onClick={onZoomIn} className={btnBase} aria-label={t("zoomIn")}>

--- a/src/components/map/GlobeScene.tsx
+++ b/src/components/map/GlobeScene.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, type RefObject } from "react";
+import { useState, useRef, useMemo, type RefObject } from "react";
 import { useFrame } from "@react-three/fiber";
 import { OrbitControls } from "@react-three/drei";
 import { StarField } from "./StarField";
@@ -8,6 +8,7 @@ import { CountryPopup } from "./CountryPopup";
 import { CountryLabels } from "./CountryLabels";
 import { useGlobeData } from "@/lib/hooks/useGlobeData";
 import { countriesData } from "@/data/countries";
+import type * as THREE from "three";
 import type { Locale } from "@/data/types";
 
 function ZoomController({ targetZRef }: { targetZRef: RefObject<number> }) {
@@ -36,6 +37,7 @@ type GlobeSceneProps = {
 export function GlobeScene({ discoveredSlugs, onCountrySelect, showLabels, targetZRef, locale, globeT, isDaylight, autoRotate, discoverCountry }: GlobeSceneProps) {
   const { countries } = useGlobeData();
   const [selectedSlug, setSelectedSlug] = useState<string | null>(null);
+  const sphereRef = useRef<THREE.Mesh>(null);
 
   const handleCountrySelect = (slug: string) => {
     setSelectedSlug(slug);
@@ -74,13 +76,13 @@ export function GlobeScene({ discoveredSlugs, onCountrySelect, showLabels, targe
       <StarField />
       <ambientLight intensity={isDaylight ? 1.0 : 0.15} />
       <directionalLight position={[5, 3, 5]} intensity={isDaylight ? 0.3 : 1.0} />
-      <GlobeSphere />
+      <GlobeSphere ref={sphereRef} />
       <CountryMeshes
         countries={countries}
         discoveredSlugs={discoveredSlugs}
         onCountrySelect={handleCountrySelect}
       />
-      <CountryLabels countries={countries} visible={showLabels} locale={locale} />
+      <CountryLabels countries={countries} visible={showLabels} locale={locale} sphereRef={sphereRef} />
       {popupData && (
         <CountryPopup
           {...popupData}

--- a/src/components/map/GlobeScene.tsx
+++ b/src/components/map/GlobeScene.tsx
@@ -10,18 +10,12 @@ import { useGlobeData } from "@/lib/hooks/useGlobeData";
 import { countriesData } from "@/data/countries";
 import type { Locale } from "@/data/types";
 
-function ZoomController({ zoomRef }: { zoomRef: RefObject<number> }) {
+function ZoomController({ targetZRef }: { targetZRef: RefObject<number> }) {
   useFrame(({ camera }) => {
-    const cmd = zoomRef.current;
-    if (cmd === 1) {
-      camera.position.z = Math.max(camera.position.z - 0.1, 1.5);
-      zoomRef.current = 0;
-    } else if (cmd === -1) {
-      camera.position.z = Math.min(camera.position.z + 0.1, 4);
-      zoomRef.current = 0;
-    } else if (cmd === 2) {
-      camera.position.set(0, 0, 2.5);
-      zoomRef.current = 0;
+    const target = targetZRef.current;
+    const diff = target - camera.position.z;
+    if (Math.abs(diff) > 0.001) {
+      camera.position.z += diff * 0.08;
     }
   });
   return null;
@@ -31,7 +25,7 @@ type GlobeSceneProps = {
   discoveredSlugs: string[];
   onCountrySelect?: (slug: string) => void;
   showLabels: boolean;
-  zoomRef: RefObject<number>;
+  targetZRef: RefObject<number>;
   locale: Locale;
   globeT: { capital: string; explore: string; markExplored: string; alreadyExplored: string };
   isDaylight: boolean;
@@ -39,7 +33,7 @@ type GlobeSceneProps = {
   discoverCountry: (slug: string) => void;
 };
 
-export function GlobeScene({ discoveredSlugs, onCountrySelect, showLabels, zoomRef, locale, globeT, isDaylight, autoRotate, discoverCountry }: GlobeSceneProps) {
+export function GlobeScene({ discoveredSlugs, onCountrySelect, showLabels, targetZRef, locale, globeT, isDaylight, autoRotate, discoverCountry }: GlobeSceneProps) {
   const { countries } = useGlobeData();
   const [selectedSlug, setSelectedSlug] = useState<string | null>(null);
 
@@ -99,7 +93,7 @@ export function GlobeScene({ discoveredSlugs, onCountrySelect, showLabels, zoomR
           onClose={() => setSelectedSlug(null)}
         />
       )}
-      <ZoomController zoomRef={zoomRef} />
+      <ZoomController targetZRef={targetZRef} />
       <OrbitControls
         enablePan={false}
         enableDamping={true}

--- a/src/components/map/GlobeScene.tsx
+++ b/src/components/map/GlobeScene.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useMemo, type RefObject } from "react";
+import { useState, useRef, useMemo, useEffect, type RefObject } from "react";
 import { useFrame } from "@react-three/fiber";
 import { OrbitControls } from "@react-three/drei";
 import { StarField } from "./StarField";
@@ -32,12 +32,18 @@ type GlobeSceneProps = {
   isDaylight: boolean;
   autoRotate: boolean;
   discoverCountry: (slug: string) => void;
+  closePopupRef: RefObject<(() => void) | null>;
 };
 
-export function GlobeScene({ discoveredSlugs, onCountrySelect, showLabels, targetZRef, locale, globeT, isDaylight, autoRotate, discoverCountry }: GlobeSceneProps) {
+export function GlobeScene({ discoveredSlugs, onCountrySelect, showLabels, targetZRef, locale, globeT, isDaylight, autoRotate, discoverCountry, closePopupRef }: GlobeSceneProps) {
   const { countries } = useGlobeData();
   const [selectedSlug, setSelectedSlug] = useState<string | null>(null);
   const sphereRef = useRef<THREE.Mesh>(null);
+
+  useEffect(() => {
+    closePopupRef.current = () => setSelectedSlug(null);
+    return () => { closePopupRef.current = null; };
+  }, [closePopupRef]);
 
   const handleCountrySelect = (slug: string) => {
     setSelectedSlug(slug);

--- a/src/components/map/GlobeScene.tsx
+++ b/src/components/map/GlobeScene.tsx
@@ -34,9 +34,10 @@ type GlobeSceneProps = {
   discoverCountry: (slug: string) => void;
   closePopupRef: RefObject<(() => void) | null>;
   globeMode: "realistic" | "political";
+  hoverMode: boolean;
 };
 
-export function GlobeScene({ discoveredSlugs, onCountrySelect, showLabels, targetZRef, locale, globeT, isDaylight, autoRotate, discoverCountry, closePopupRef, globeMode }: GlobeSceneProps) {
+export function GlobeScene({ discoveredSlugs, onCountrySelect, showLabels, targetZRef, locale, globeT, isDaylight, autoRotate, discoverCountry, closePopupRef, globeMode, hoverMode }: GlobeSceneProps) {
   const { countries } = useGlobeData();
   const [selectedSlug, setSelectedSlug] = useState<string | null>(null);
   const sphereRef = useRef<THREE.Mesh>(null);
@@ -89,6 +90,15 @@ export function GlobeScene({ discoveredSlugs, onCountrySelect, showLabels, targe
         discoveredSlugs={discoveredSlugs}
         onCountrySelect={handleCountrySelect}
         mode={globeMode}
+        hoverMode={hoverMode}
+        onCountryHover={(slug) => {
+          if (slug === null) {
+            setSelectedSlug(null);
+          } else {
+            setSelectedSlug(slug);
+            onCountrySelect?.(slug);
+          }
+        }}
       />
       <CountryLabels countries={countries} visible={showLabels} locale={locale} sphereRef={sphereRef} />
       {popupData && (

--- a/src/components/map/GlobeScene.tsx
+++ b/src/components/map/GlobeScene.tsx
@@ -33,9 +33,10 @@ type GlobeSceneProps = {
   autoRotate: boolean;
   discoverCountry: (slug: string) => void;
   closePopupRef: RefObject<(() => void) | null>;
+  globeMode: "realistic" | "political";
 };
 
-export function GlobeScene({ discoveredSlugs, onCountrySelect, showLabels, targetZRef, locale, globeT, isDaylight, autoRotate, discoverCountry, closePopupRef }: GlobeSceneProps) {
+export function GlobeScene({ discoveredSlugs, onCountrySelect, showLabels, targetZRef, locale, globeT, isDaylight, autoRotate, discoverCountry, closePopupRef, globeMode }: GlobeSceneProps) {
   const { countries } = useGlobeData();
   const [selectedSlug, setSelectedSlug] = useState<string | null>(null);
   const sphereRef = useRef<THREE.Mesh>(null);
@@ -82,11 +83,12 @@ export function GlobeScene({ discoveredSlugs, onCountrySelect, showLabels, targe
       <StarField />
       <ambientLight intensity={isDaylight ? 1.0 : 0.15} />
       <directionalLight position={[5, 3, 5]} intensity={isDaylight ? 0.3 : 1.0} />
-      <GlobeSphere ref={sphereRef} />
+      <GlobeSphere ref={sphereRef} mode={globeMode} />
       <CountryMeshes
         countries={countries}
         discoveredSlugs={discoveredSlugs}
         onCountrySelect={handleCountrySelect}
+        mode={globeMode}
       />
       <CountryLabels countries={countries} visible={showLabels} locale={locale} sphereRef={sphereRef} />
       {popupData && (

--- a/src/components/map/GlobeSphere.tsx
+++ b/src/components/map/GlobeSphere.tsx
@@ -2,12 +2,20 @@ import { forwardRef } from "react";
 import { useTexture } from "@react-three/drei";
 import type * as THREE from "three";
 
-export const GlobeSphere = forwardRef<THREE.Mesh>(function GlobeSphere(_, ref) {
+type GlobeSphereProps = {
+  mode: "realistic" | "political";
+};
+
+export const GlobeSphere = forwardRef<THREE.Mesh, GlobeSphereProps>(function GlobeSphere({ mode }, ref) {
   const texture = useTexture("/textures/earth-day.jpg");
   return (
     <mesh ref={ref}>
       <sphereGeometry args={[1, 64, 64]} />
-      <meshStandardMaterial map={texture} roughness={0.8} metalness={0.1} />
+      {mode === "realistic" ? (
+        <meshStandardMaterial map={texture} roughness={0.8} metalness={0.1} />
+      ) : (
+        <meshStandardMaterial color="#1a2340" roughness={0.8} metalness={0.1} />
+      )}
     </mesh>
   );
 });

--- a/src/components/map/GlobeSphere.tsx
+++ b/src/components/map/GlobeSphere.tsx
@@ -1,11 +1,13 @@
+import { forwardRef } from "react";
 import { useTexture } from "@react-three/drei";
+import type * as THREE from "three";
 
-export function GlobeSphere() {
+export const GlobeSphere = forwardRef<THREE.Mesh>(function GlobeSphere(_, ref) {
   const texture = useTexture("/textures/earth-day.jpg");
   return (
-    <mesh>
+    <mesh ref={ref}>
       <sphereGeometry args={[1, 64, 64]} />
       <meshStandardMaterial map={texture} roughness={0.8} metalness={0.1} />
     </mesh>
   );
-}
+});


### PR DESCRIPTION
## Summary

Closes #45

Eight UX improvements to the interactive globe page:

### Changes

| # | Improvement | Commits |
|---|---|---|
| 1 | **i18n keys** — all new globe UX strings added to EN + ES | `8188a07c` |
| 2 | **Transparent TopNav** — map page nav overlays the globe with blur | `08c2a41b` |
| 3 | **Back navigation** — country detail "Back" link returns to map when coming from `?from=map` | `5a4de223` |
| 4 | **Smooth zoom lerp** — zoom interpolates at 8% per frame instead of jumping | `4a3ec00c` |
| 5 | **Label fixes** — back-face culling, fixed pixel size (no scale-with-zoom), no text selection | `dc25e9d7` |
| 6 | **Outside-click dismiss** — clicking empty canvas space closes the country popup | `023a3010` |
| 7 | **Rendering mode toggle** — satellite_alt button switches between political (continent colours) and realistic (NASA texture) globe | `db6d9832` |
| 8 | **Hover-to-preview** — touch_app button enables hover-to-show-popup mode | `1bf44fe0` |
| 9 | **Geolocation button** — blue my_location button flies camera to user's coordinates; 3-second error toast on failure; reset split to separate refresh button | `600c9fcf` |

### Testing
- `npm test` — 132/132 passing
- `npm run build` — zero errors
- `npx tsc --noEmit` — clean after each commit