### PR TITLE
fix(globe): fix 6 globe UX/visual bugs — rotation, flicker, lighting, artifacts

### DIFF
--- a/src/__tests__/utils/geo.test.ts
+++ b/src/__tests__/utils/geo.test.ts
@@ -4,8 +4,10 @@ import {
   computeCentroid,
   getCountryFlagCode,
   ISO_NUMERIC_TO_ALPHA2,
+  subdivideRing,
+  triangulatePolygon,
 } from "@/lib/utils/geo";
-import type { Feature } from "geojson";
+import type { Feature, Position } from "geojson";
 
 // ---------------------------------------------------------------------------
 // latLngToCartesian
@@ -153,5 +155,62 @@ describe("ISO_NUMERIC_TO_ALPHA2", () => {
     for (const code of Object.values(ISO_NUMERIC_TO_ALPHA2)) {
       expect(code).toMatch(/^[a-z]{2}$/);
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// subdivideRing
+// ---------------------------------------------------------------------------
+
+describe("subdivideRing", () => {
+  it("returns the same ring when all segments are under 5°", () => {
+    const ring: Position[] = [[0, 0], [1, 0], [0, 1]];
+    const result = subdivideRing(ring);
+    expect(result).toHaveLength(3);
+  });
+
+  it("inserts intermediate points for segments spanning > 5°", () => {
+    const ring: Position[] = [[0, 0], [15, 0], [0, 1]];
+    const result = subdivideRing(ring);
+    expect(result.length).toBeGreaterThan(3);
+  });
+
+  it("handles a ring with fewer than 2 points without crashing", () => {
+    const ring: Position[] = [[0, 0]];
+    expect(() => subdivideRing(ring)).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// triangulatePolygon
+// ---------------------------------------------------------------------------
+
+describe("triangulatePolygon", () => {
+  it("returns null for empty rings array", () => {
+    expect(triangulatePolygon([], 1)).toBeNull();
+  });
+
+  it("returns null for a degenerate ring with < 3 points", () => {
+    const rings: Position[][] = [[[0, 0], [1, 0]]];
+    expect(triangulatePolygon(rings, 1)).toBeNull();
+  });
+
+  it("triangulates a simple convex polygon (outer ring only)", () => {
+    const outerRing: Position[] = [
+      [0, 0], [2, 0], [2, 2], [0, 2], [0, 0],
+    ];
+    const result = triangulatePolygon([outerRing], 1);
+    expect(result).not.toBeNull();
+    expect(result!.indices.length).toBe(6);
+    expect(result!.positions.length).toBe(12);
+  });
+
+  it("triangulates a polygon with a hole and returns valid triangle indices", () => {
+    const outerRing: Position[] = [[-4, -4], [4, -4], [4, 4], [-4, 4]];
+    const holeRing: Position[] = [[-1, -1], [1, -1], [1, 1], [-1, 1]];
+    const result = triangulatePolygon([outerRing, holeRing], 1);
+    expect(result).not.toBeNull();
+    expect(result!.indices.length).toBeGreaterThan(0);
+    expect(result!.indices.length % 3).toBe(0);
   });
 });

--- a/src/components/map/CountryMeshes.tsx
+++ b/src/components/map/CountryMeshes.tsx
@@ -71,7 +71,12 @@ export function CountryMeshes({
               roughness={0.6}
               metalness={0.1}
               transparent={mode === "realistic"}
-              opacity={mode === "realistic" ? 0 : 1}
+              opacity={mode === "realistic" ? 0.15 : 1}
+              depthWrite={mode !== "realistic"}
+              side={THREE.DoubleSide}
+              polygonOffset={true}
+              polygonOffsetFactor={-1}
+              polygonOffsetUnits={-1}
             />
           </mesh>
         );

--- a/src/components/map/CountryPopup.tsx
+++ b/src/components/map/CountryPopup.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect } from "react";
-import { Html } from "@react-three/drei";
 import type { FunFact } from "@/data/types";
 
 const CONTINENT_DOT_COLORS: Record<string, string> = {
@@ -20,7 +19,6 @@ type CountryPopupProps = {
   capital: string;
   continent: string;
   funFact: FunFact | null;
-  centroid: [number, number, number];
   locale: string;
   capitalLabel: string;
   exploreLabel: string;
@@ -38,7 +36,6 @@ export function CountryPopup({
   capital,
   continent,
   funFact,
-  centroid,
   locale,
   capitalLabel,
   exploreLabel,
@@ -58,11 +55,10 @@ export function CountryPopup({
   }, [onClose]);
 
   return (
-    <Html position={centroid} center>
-      <div
-        onClick={(e) => e.stopPropagation()}
-        className="min-w-[240px] max-w-[280px] rounded-2xl border border-white/10 bg-black/60 p-4 text-white shadow-2xl backdrop-blur-xl"
-      >
+    <div
+      onClick={(e) => e.stopPropagation()}
+      className="min-w-[240px] max-w-[280px] rounded-2xl border border-white/10 bg-black/60 p-4 text-white shadow-2xl backdrop-blur-xl"
+    >
         {/* Header: flag + name + close */}
         <div className="mb-3 flex items-center gap-3">
           <img
@@ -135,7 +131,6 @@ export function CountryPopup({
         >
           {exploreLabel}
         </a>
-      </div>
-    </Html>
+    </div>
   );
 }

--- a/src/components/map/Globe.tsx
+++ b/src/components/map/Globe.tsx
@@ -1,9 +1,11 @@
 "use client";
 
-import { Suspense, lazy, useState, useRef, useEffect } from "react";
+import { Suspense, lazy, useState, useRef, useEffect, useMemo } from "react";
 import { Canvas } from "@react-three/fiber";
 import { useLocale, useTranslations } from "next-intl";
 import { GlobeControls } from "./GlobeControls";
+import { CountryPopup } from "./CountryPopup";
+import { countriesData } from "@/data/countries";
 import type { Locale } from "@/data/types";
 import type { RootState } from "@react-three/fiber";
 
@@ -25,6 +27,7 @@ export function Globe({ discoveredSlugs, onCountrySelect, discoverCountry }: Glo
   const [autoRotate, setAutoRotate] = useState(true);
   const [globeMode, setGlobeMode] = useState<"realistic" | "political">("political");
   const [hoverMode, setHoverMode] = useState(false);
+  const [selectedSlug, setSelectedSlug] = useState<string | null>(null);
   const [geolocating, setGeolocating] = useState(false);
   const [geoError, setGeoError] = useState<string | null>(null);
   const geoErrorTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -32,6 +35,27 @@ export function Globe({ discoveredSlugs, onCountrySelect, discoverCountry }: Glo
   const closePopupRef = useRef<(() => void) | null>(null);
   const locale = useLocale() as Locale;
   const t = useTranslations("globe");
+
+  // Keep closePopupRef in sync with selectedSlug setter
+  useEffect(() => {
+    closePopupRef.current = () => setSelectedSlug(null);
+  });
+
+  const popupData = useMemo(() => {
+    if (!selectedSlug) return null;
+    const entry = countriesData.find((c) => c.slug === selectedSlug);
+    if (!entry) return null;
+    const tr = entry.translations[locale];
+    return {
+      slug: entry.slug,
+      flagCode: entry.flagCode,
+      name: tr.name,
+      capital: tr.capital,
+      continent: entry.continent,
+      funFact: tr.funFacts.length > 0 ? tr.funFacts[0] : null,
+      isDiscovered: discoveredSlugs.includes(entry.slug),
+    };
+  }, [selectedSlug, locale, discoveredSlugs]);
 
   const handleReset = () => {
     if (cameraRef.current) {
@@ -127,9 +151,27 @@ export function Globe({ discoveredSlugs, onCountrySelect, discoverCountry }: Glo
             closePopupRef={closePopupRef}
             globeMode={globeMode}
             hoverMode={hoverMode}
+            selectedSlug={selectedSlug}
+            setSelectedSlug={setSelectedSlug}
           />
         </Suspense>
       </Canvas>
+      {popupData && (
+        <div className="pointer-events-none absolute left-6 top-1/2 z-30 -translate-y-1/2">
+          <div className="pointer-events-auto">
+            <CountryPopup
+              {...popupData}
+              locale={locale}
+              capitalLabel={t("capital")}
+              exploreLabel={t("explore")}
+              markExploredLabel={t("markExplored")}
+              alreadyExploredLabel={t("alreadyExplored")}
+              onMarkExplored={discoverCountry}
+              onClose={() => setSelectedSlug(null)}
+            />
+          </div>
+        </div>
+      )}
       <GlobeControls
         onReset={handleReset}
         showLabels={showLabels}

--- a/src/components/map/Globe.tsx
+++ b/src/components/map/Globe.tsx
@@ -28,22 +28,12 @@ export function Globe({ discoveredSlugs, onCountrySelect, discoverCountry }: Glo
   const [geolocating, setGeolocating] = useState(false);
   const [geoError, setGeoError] = useState<string | null>(null);
   const geoErrorTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const targetZRef = useRef<number>(2.5);
   const cameraRef = useRef<RootState["camera"] | null>(null);
   const closePopupRef = useRef<(() => void) | null>(null);
   const locale = useLocale() as Locale;
   const t = useTranslations("globe");
 
-  const handleZoomIn = () => {
-    const currentZ = cameraRef.current?.position.z ?? 2.5;
-    targetZRef.current = Math.max(currentZ - 0.5, 1.5);
-  };
-  const handleZoomOut = () => {
-    const currentZ = cameraRef.current?.position.z ?? 2.5;
-    targetZRef.current = Math.min(currentZ + 0.5, 4.0);
-  };
   const handleReset = () => {
-    targetZRef.current = 2.5;
     if (cameraRef.current) {
       cameraRef.current.position.set(0, 0, 2.5);
     }
@@ -69,7 +59,6 @@ export function Globe({ discoveredSlugs, onCountrySelect, discoverCountry }: Glo
         const z = r * Math.sin(phi) * Math.sin(theta);
         if (cameraRef.current) {
           cameraRef.current.position.set(x, y, z);
-          targetZRef.current = r;
         }
         setGeolocating(false);
       },
@@ -89,7 +78,6 @@ export function Globe({ discoveredSlugs, onCountrySelect, discoverCountry }: Glo
       if (saved) {
         const { x, y, z } = JSON.parse(saved);
         state.camera.position.set(x, y, z);
-        targetZRef.current = z;
       }
     } catch {
       // sessionStorage unavailable — ignore
@@ -126,7 +114,6 @@ export function Globe({ discoveredSlugs, onCountrySelect, discoverCountry }: Glo
             discoveredSlugs={discoveredSlugs}
             onCountrySelect={onCountrySelect}
             showLabels={showLabels}
-            targetZRef={targetZRef}
             locale={locale}
             globeT={{
               capital: t("capital"),
@@ -144,8 +131,6 @@ export function Globe({ discoveredSlugs, onCountrySelect, discoverCountry }: Glo
         </Suspense>
       </Canvas>
       <GlobeControls
-        onZoomIn={handleZoomIn}
-        onZoomOut={handleZoomOut}
         onReset={handleReset}
         showLabels={showLabels}
         onToggleLabels={() => setShowLabels((v) => !v)}

--- a/src/components/map/GlobeControls.tsx
+++ b/src/components/map/GlobeControls.tsx
@@ -1,8 +1,6 @@
 import { useTranslations } from "next-intl";
 
 type GlobeControlsProps = {
-  onZoomIn: () => void;
-  onZoomOut: () => void;
   onReset: () => void;
   showLabels: boolean;
   onToggleLabels: () => void;
@@ -19,8 +17,6 @@ type GlobeControlsProps = {
 };
 
 export function GlobeControls({
-  onZoomIn,
-  onZoomOut,
   onReset,
   showLabels,
   onToggleLabels,
@@ -76,12 +72,6 @@ export function GlobeControls({
         <span className="material-symbols-outlined">
           {hoverMode ? "mouse" : "touch_app"}
         </span>
-      </button>
-      <button onClick={onZoomIn} className={btnBase} aria-label={t("zoomIn")}>
-        <span className="material-symbols-outlined">add</span>
-      </button>
-      <button onClick={onZoomOut} className={btnBase} aria-label={t("zoomOut")}>
-        <span className="material-symbols-outlined">remove</span>
       </button>
       <button
         onClick={onToggleLabels}

--- a/src/components/map/GlobeScene.tsx
+++ b/src/components/map/GlobeScene.tsx
@@ -1,12 +1,10 @@
-import { useState, useRef, useMemo, useEffect, type RefObject } from "react";
+import { useRef, type RefObject } from "react";
 import { OrbitControls } from "@react-three/drei";
 import { StarField } from "./StarField";
 import { GlobeSphere } from "./GlobeSphere";
 import { CountryMeshes } from "./CountryMeshes";
-import { CountryPopup } from "./CountryPopup";
 import { CountryLabels } from "./CountryLabels";
 import { useGlobeData } from "@/lib/hooks/useGlobeData";
-import { countriesData } from "@/data/countries";
 import type * as THREE from "three";
 import type { Locale } from "@/data/types";
 
@@ -22,54 +20,23 @@ type GlobeSceneProps = {
   closePopupRef: RefObject<(() => void) | null>;
   globeMode: "realistic" | "political";
   hoverMode: boolean;
+  selectedSlug: string | null;
+  setSelectedSlug: (slug: string | null) => void;
 };
 
-export function GlobeScene({ discoveredSlugs, onCountrySelect, showLabels, locale, globeT, isDaylight, autoRotate, discoverCountry, closePopupRef, globeMode, hoverMode }: GlobeSceneProps) {
+export function GlobeScene({ discoveredSlugs, onCountrySelect, showLabels, locale, globeT, isDaylight, autoRotate, discoverCountry, closePopupRef, globeMode, hoverMode, selectedSlug, setSelectedSlug }: GlobeSceneProps) {
   const { countries } = useGlobeData();
-  const [selectedSlug, setSelectedSlug] = useState<string | null>(null);
   const sphereRef = useRef<THREE.Mesh>(null);
-
-  useEffect(() => {
-    closePopupRef.current = () => setSelectedSlug(null);
-    return () => { closePopupRef.current = null; };
-  }, [closePopupRef]);
 
   const handleCountrySelect = (slug: string) => {
     setSelectedSlug(slug);
     onCountrySelect?.(slug);
   };
 
-  const popupData = useMemo(() => {
-    if (!selectedSlug) return null;
-
-    const processed = countries.find((c) => c.slug === selectedSlug);
-    if (!processed) return null;
-
-    const entry = countriesData.find((c) => c.slug === selectedSlug);
-    if (!entry) return null;
-
-    const tr = entry.translations[locale];
-    const funFact =
-      tr.funFacts.length > 0
-        ? tr.funFacts[0]
-        : null;
-
-    return {
-      slug: entry.slug,
-      flagCode: entry.flagCode,
-      name: tr.name,
-      capital: tr.capital,
-      continent: entry.continent,
-      funFact,
-      centroid: processed.centroid,
-      isDiscovered: discoveredSlugs.includes(entry.slug),
-    };
-  }, [selectedSlug, countries, locale, discoveredSlugs]);
-
   return (
     <>
       <StarField />
-      <ambientLight intensity={isDaylight ? 1.0 : 0.15} />
+      <ambientLight intensity={globeMode === "realistic" ? 1.0 : isDaylight ? 1.0 : 0.4} />
       <directionalLight position={[5, 3, 5]} intensity={isDaylight ? 0.3 : 1.0} />
       <GlobeSphere ref={sphereRef} mode={globeMode} />
       <CountryMeshes
@@ -79,27 +46,11 @@ export function GlobeScene({ discoveredSlugs, onCountrySelect, showLabels, local
         mode={globeMode}
         hoverMode={hoverMode}
         onCountryHover={(slug) => {
-          if (slug === null) {
-            setSelectedSlug(null);
-          } else {
-            setSelectedSlug(slug);
-            onCountrySelect?.(slug);
-          }
+          setSelectedSlug(slug);
+          if (slug) onCountrySelect?.(slug);
         }}
       />
       <CountryLabels countries={countries} visible={showLabels} locale={locale} sphereRef={sphereRef} />
-      {popupData && (
-        <CountryPopup
-          {...popupData}
-          locale={locale}
-          capitalLabel={globeT.capital}
-          exploreLabel={globeT.explore}
-          markExploredLabel={globeT.markExplored}
-          alreadyExploredLabel={globeT.alreadyExplored}
-          onMarkExplored={discoverCountry}
-          onClose={() => setSelectedSlug(null)}
-        />
-      )}
       <OrbitControls
         enablePan={false}
         enableZoom={true}

--- a/src/components/map/GlobeScene.tsx
+++ b/src/components/map/GlobeScene.tsx
@@ -1,5 +1,4 @@
 import { useState, useRef, useMemo, useEffect, type RefObject } from "react";
-import { useFrame } from "@react-three/fiber";
 import { OrbitControls } from "@react-three/drei";
 import { StarField } from "./StarField";
 import { GlobeSphere } from "./GlobeSphere";
@@ -11,22 +10,10 @@ import { countriesData } from "@/data/countries";
 import type * as THREE from "three";
 import type { Locale } from "@/data/types";
 
-function ZoomController({ targetZRef }: { targetZRef: RefObject<number> }) {
-  useFrame(({ camera }) => {
-    const target = targetZRef.current;
-    const diff = target - camera.position.z;
-    if (Math.abs(diff) > 0.001) {
-      camera.position.z += diff * 0.08;
-    }
-  });
-  return null;
-}
-
 type GlobeSceneProps = {
   discoveredSlugs: string[];
   onCountrySelect?: (slug: string) => void;
   showLabels: boolean;
-  targetZRef: RefObject<number>;
   locale: Locale;
   globeT: { capital: string; explore: string; markExplored: string; alreadyExplored: string };
   isDaylight: boolean;
@@ -37,7 +24,7 @@ type GlobeSceneProps = {
   hoverMode: boolean;
 };
 
-export function GlobeScene({ discoveredSlugs, onCountrySelect, showLabels, targetZRef, locale, globeT, isDaylight, autoRotate, discoverCountry, closePopupRef, globeMode, hoverMode }: GlobeSceneProps) {
+export function GlobeScene({ discoveredSlugs, onCountrySelect, showLabels, locale, globeT, isDaylight, autoRotate, discoverCountry, closePopupRef, globeMode, hoverMode }: GlobeSceneProps) {
   const { countries } = useGlobeData();
   const [selectedSlug, setSelectedSlug] = useState<string | null>(null);
   const sphereRef = useRef<THREE.Mesh>(null);
@@ -113,9 +100,9 @@ export function GlobeScene({ discoveredSlugs, onCountrySelect, showLabels, targe
           onClose={() => setSelectedSlug(null)}
         />
       )}
-      <ZoomController targetZRef={targetZRef} />
       <OrbitControls
         enablePan={false}
+        enableZoom={true}
         enableDamping={true}
         dampingFactor={0.05}
         minDistance={1.5}

--- a/src/lib/utils/geo.ts
+++ b/src/lib/utils/geo.ts
@@ -119,47 +119,92 @@ function projectToTangentPlane(
   return result;
 }
 
-function triangulateRing(
-  ring: Position[],
+/**
+ * Insert intermediate points so no segment spans more than 5° in lat or lng.
+ * Reduces tangent-plane distortion for large countries like Russia / Canada.
+ */
+export function subdivideRing(ring: Position[]): Position[] {
+  const THRESHOLD_DEG = 5;
+  if (ring.length < 2) return ring;
+  const result: Position[] = [];
+  for (let i = 0; i < ring.length; i++) {
+    const a = ring[i];
+    const b = ring[(i + 1) % ring.length];
+    result.push(a);
+    const steps = Math.max(
+      Math.ceil(Math.abs(b[0] - a[0]) / THRESHOLD_DEG),
+      Math.ceil(Math.abs(b[1] - a[1]) / THRESHOLD_DEG),
+    );
+    for (let s = 1; s < steps; s++) {
+      const t = s / steps;
+      result.push([a[0] + t * (b[0] - a[0]), a[1] + t * (b[1] - a[1])]);
+    }
+  }
+  return result;
+}
+
+/**
+ * Triangulate a polygon (outer ring + optional holes) projected onto a sphere.
+ * All rings in `rings` are subdivided before projection to reduce distortion.
+ */
+export function triangulatePolygon(
+  rings: Position[][],
   radius: number,
 ): { positions: number[]; indices: number[] } | null {
-  // Remove closing vertex if it duplicates the first
-  let coords = ring;
-  if (
-    coords.length > 1 &&
-    coords[0][0] === coords[coords.length - 1][0] &&
-    coords[0][1] === coords[coords.length - 1][1]
-  ) {
-    coords = coords.slice(0, -1);
+  // Normalize rings: remove closing duplicate vertex, discard degenerate rings
+  const normalized = rings
+    .map((ring) => {
+      let coords = ring;
+      if (
+        coords.length > 1 &&
+        coords[0][0] === coords[coords.length - 1][0] &&
+        coords[0][1] === coords[coords.length - 1][1]
+      ) {
+        coords = coords.slice(0, -1);
+      }
+      return coords;
+    })
+    .filter((r) => r.length >= 3);
+
+  if (normalized.length === 0) return null;
+
+  const subdivided = normalized.map(subdivideRing);
+
+  // Compute combined centroid for stable tangent-plane basis
+  let cx = 0, cy = 0, cz = 0, totalVerts = 0;
+  for (const ring of subdivided) {
+    for (const [lng, lat] of ring) {
+      const [x, y, z] = latLngToCartesian(lat, lng, radius);
+      cx += x; cy += y; cz += z;
+      totalVerts++;
+    }
   }
-  if (coords.length < 3) return null;
+  if (totalVerts === 0) return null;
 
-  // Build 3D positions
-  const positions3D = new Float64Array(coords.length * 3);
-  let cx = 0,
-    cy = 0,
-    cz = 0;
+  const centroid = new Vector3(cx / totalVerts, cy / totalVerts, cz / totalVerts);
 
-  for (let i = 0; i < coords.length; i++) {
-    const [lng, lat] = coords[i];
-    const [x, y, z] = latLngToCartesian(lat, lng, radius);
-    positions3D[i * 3] = x;
-    positions3D[i * 3 + 1] = y;
-    positions3D[i * 3 + 2] = z;
-    cx += x;
-    cy += y;
-    cz += z;
+  // Build flat 3D array and track where each hole ring starts
+  const positions3D = new Float64Array(totalVerts * 3);
+  const holeIndices: number[] = [];
+  let offset = 0;
+
+  for (let ri = 0; ri < subdivided.length; ri++) {
+    if (ri > 0) holeIndices.push(offset);
+    for (const [lng, lat] of subdivided[ri]) {
+      const [x, y, z] = latLngToCartesian(lat, lng, radius);
+      positions3D[offset * 3] = x;
+      positions3D[offset * 3 + 1] = y;
+      positions3D[offset * 3 + 2] = z;
+      offset++;
+    }
   }
 
-  const centroid = new Vector3(
-    cx / coords.length,
-    cy / coords.length,
-    cz / coords.length,
-  );
-
-  // Project to 2D, triangulate
   const coords2D = projectToTangentPlane(positions3D, centroid);
-  const indices = earcut(Array.from(coords2D), undefined, 2);
+  const indices = earcut(
+    Array.from(coords2D),
+    holeIndices.length > 0 ? holeIndices : undefined,
+    2,
+  );
   if (indices.length === 0) return null;
 
   return { positions: Array.from(positions3D), indices };
@@ -187,11 +232,7 @@ export function buildCountryGeometry(
   let indexOffset = 0;
 
   for (const polygon of polygons) {
-    // Use only the outer ring (index 0) — skip holes for globe display
-    const outerRing = polygon[0];
-    if (!outerRing) continue;
-
-    const result = triangulateRing(outerRing, radius);
+    const result = triangulatePolygon(polygon, radius);
     if (!result) continue;
 
     allPositions.push(...result.positions);


### PR DESCRIPTION
Closes #47

## Changes

### Phase 1 — Rotation unlock + zoom buttons removal
- Deleted `ZoomController` (the per-frame camera-z driver that fought user rotation and blocked reaching China/antipodes)
- Removed zoom buttons (+/−) from `GlobeControls` (scroll wheel now handles zoom natively via OrbitControls)
- Enabled `enableZoom={true}` on `<OrbitControls>`

### Phase 2 — Popup flicker fix
- Lifted `CountryPopup` out of the Three.js `<Canvas>` into a fixed DOM overlay (`absolute left-6 top-1/2 -translate-y-1/2`)
- Removed `<Html position={centroid}>` wrapper (was repositioning every frame due to OrbitControls damping → flicker)
- State and popup data now owned by `Globe.tsx`; `GlobeScene` receives `selectedSlug`/`setSelectedSlug` as props

### Phase 3 — Lighting fixes
- Realistic mode: ambient forced to `1.0` (earth texture has baked lighting)
- Night mode: ambient floor raised `0.15 → 0.4` (political globe now visible)
- Country meshes in realistic mode: `opacity: 0 → 0.15` so overlay is visible

### Phase 4 — Polygon artifacts
- `CountryMeshes`: added `THREE.DoubleSide` (back-faces were invisible), `polygonOffset` (depth fighting)
- `geo.ts`: added `subdivideRing()` — inserts intermediate points every 5° to reduce tangent-plane distortion for large countries
- `geo.ts`: replaced outer-ring-only `triangulateRing` with `triangulatePolygon(rings, radius)` that passes hole indices to earcut — Great Lakes, Caspian, etc. now correctly punched out
- 7 new tests covering `subdivideRing` and `triangulatePolygon`

## Test results
139/139 passing