### PR TITLE
fix(globe): antimeridian polygon support — Russia hollow ring

### DIFF
--- a/src/__tests__/utils/geo.test.ts
+++ b/src/__tests__/utils/geo.test.ts
@@ -277,11 +277,51 @@ describe("getInteriorGeoPoints", () => {
     }
   });
 
-  it("returns [] for antimeridian-crossing bbox (maxLng < minLng)", () => {
-    // Polygon straddling ±180° — geoBounds returns inverted range
-    const rings: Position[][] = [[[170, -10], [190, -10], [190, 10], [170, 10]]];
-    // We expect an empty result (antimeridian-crossing guard)
-    const pts = getInteriorGeoPoints(rings, 5);
-    expect(Array.isArray(pts)).toBe(true);
+  it("returns interior points for a Russia-like antimeridian-crossing polygon", () => {
+    // Russia's ring has vertices near ±180° on BOTH sides (the antimeridian is
+    // Russia's eastern coastline in Natural Earth data). The ring has no explicit
+    // ±180 vertex; instead there's an edge from +179° to −179° which d3-geo detects
+    // as a genuine antimeridian crossing (delta_lng = -358, |358| > 180).
+    //
+    // geoBounds on this CW ring returns [[27,41],[-168,82]] — inverted bounds where
+    // maxLng=-168 < minLng=27. The old guard `if (maxLng < minLng) return []` fired
+    // here → hollow ring bug. After the fix, interior points must be produced.
+    const rings: Position[][] = [[
+      [27, 41], [100, 41], [179, 41], [-179, 41], [-168, 41],
+      [-168, 72], [-179, 72], [179, 72], [100, 72], [27, 72],
+    ]];
+    const pts = getInteriorGeoPoints(rings, 10);
+    // Must produce interior seed points — not bail out with []
+    expect(pts.length).toBeGreaterThan(0);
+    // All returned points must be valid geographic coordinates
+    for (const [lng, lat] of pts) {
+      expect(lng).toBeGreaterThanOrEqual(-180);
+      expect(lng).toBeLessThanOrEqual(180);
+      expect(lat).toBeGreaterThan(35);
+      expect(lat).toBeLessThan(90);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// triangulatePolygon — antimeridian regression
+// ---------------------------------------------------------------------------
+
+describe("triangulatePolygon — antimeridian regression", () => {
+  it("returns non-null for a Russia-like polygon crossing ±180°", () => {
+    // Same Russia-like ring: vertices near ±179° on both sides of antimeridian.
+    // With old code: geoBounds returns inverted → getInteriorGeoPoints returns []
+    // → earcut on SLERP-subdivided ring sees coordinate jump at ±179° as
+    //   self-intersecting → returns [] → triangulatePolygon returns null.
+    // After the fix this must succeed.
+    const rings: Position[][] = [[
+      [27, 41], [100, 41], [179, 41], [-179, 41], [-168, 41],
+      [-168, 72], [-179, 72], [179, 72], [100, 72], [27, 72],
+    ]];
+    const result = triangulatePolygon(rings, 1);
+    // Before the fix this returned null. After the fix it must succeed.
+    expect(result).not.toBeNull();
+    expect(result!.positions.length).toBeGreaterThan(0);
+    expect(result!.indices.length).toBeGreaterThan(0);
   });
 });

--- a/src/lib/utils/geo.ts
+++ b/src/lib/utils/geo.ts
@@ -6,7 +6,7 @@ import {
   Float32BufferAttribute,
 } from "three";
 import Delaunator from "delaunator";
-import { geoBounds, geoContains } from "d3-geo";
+import { geoContains } from "d3-geo";
 import type { Topology, GeometryCollection } from "topojson-specification";
 import type { Feature, MultiPolygon, Polygon, Position } from "geojson";
 
@@ -100,14 +100,17 @@ export function getInteriorGeoPoints(
   rings: Position[][],
   resolution: number,
 ): Position[] {
-  // d3-geo requires properly closed rings (first === last vertex) for correct
-  // bounds and containment checks.
-  const closedRings = rings.map((ring) => [...ring, ring[0]]);
-  const polygon = { type: "Polygon" as const, coordinates: closedRings };
-  const [[minLng, minLat], [maxLng, maxLat]] = geoBounds(polygon);
-
-  // Skip antimeridian-crossing or degenerate bounding boxes
-  if (maxLng < minLng) return [];
+  // Scan outer ring vertices directly — avoids geoBounds which returns inverted
+  // bounds for antimeridian-crossing polygons (e.g. Russia), triggering a false
+  // `maxLng < minLng` guard that made the function return [] for such countries.
+  const outer = rings[0];
+  let minLng = Infinity, maxLng = -Infinity, minLat = Infinity, maxLat = -Infinity;
+  for (const [lng, lat] of outer) {
+    if (lng < minLng) minLng = lng;
+    if (lng > maxLng) maxLng = lng;
+    if (lat < minLat) minLat = lat;
+    if (lat > maxLat) maxLat = lat;
+  }
 
   const lngSpan = maxLng - minLng;
   const latSpan = maxLat - minLat;
@@ -115,12 +118,41 @@ export function getInteriorGeoPoints(
   // Skip tiny polygons — flat earcut handles them fine without interior seeding
   if (lngSpan < resolution && latSpan < resolution) return [];
 
+  // d3-geo requires properly closed rings (first === last vertex) for correct
+  // containment checks.
+  const closedRings = rings.map((ring) => [...ring, ring[0]]);
+  const polygon = { type: "Polygon" as const, coordinates: closedRings };
   const result: Position[] = [];
-  // Offset by half-resolution to centre the first grid point inside each cell
-  for (let lat = minLat + resolution / 2; lat < maxLat; lat += resolution) {
-    for (let lng = minLng + resolution / 2; lng < maxLng; lng += resolution) {
-      if (geoContains(polygon, [lng, lat])) {
-        result.push([lng, lat]);
+
+  if (lngSpan <= 180) {
+    // Normal (non-antimeridian-crossing) polygon: single rectangular grid.
+    for (let lat = minLat + resolution / 2; lat < maxLat; lat += resolution) {
+      for (let lng = minLng + resolution / 2; lng < maxLng; lng += resolution) {
+        if (geoContains(polygon, [lng, lat])) result.push([lng, lat]);
+      }
+    }
+  } else {
+    // Antimeridian-crossing polygon (lngSpan > 180°, e.g. Russia, Fiji, Kiribati).
+    // The raw vertex range spans both sides of ±180°. Generate two sub-grids:
+    //   • Western sub-range: [minLngPositive .. 180)
+    //   • Eastern sub-range: (-180 .. maxLngNegative]
+    // Both filtered by geoContains which handles antimeridian correctly.
+    let minLngPos = Infinity, maxLngNeg = -Infinity;
+    for (const [lng] of outer) {
+      if (lng >= 0 && lng < minLngPos) minLngPos = lng;
+      if (lng < 0 && lng > maxLngNeg) maxLngNeg = lng;
+    }
+
+    // Western sub-range [minLngPos..180)
+    for (let lat = minLat + resolution / 2; lat < maxLat; lat += resolution) {
+      for (let lng = minLngPos + resolution / 2; lng < 180; lng += resolution) {
+        if (geoContains(polygon, [lng, lat])) result.push([lng, lat]);
+      }
+    }
+    // Eastern sub-range (-180..maxLngNeg]
+    for (let lat = minLat + resolution / 2; lat < maxLat; lat += resolution) {
+      for (let lng = -180 + resolution / 2; lng <= maxLngNeg; lng += resolution) {
+        if (geoContains(polygon, [lng, lat])) result.push([lng, lat]);
       }
     }
   }
@@ -278,7 +310,19 @@ export function triangulatePolygon(
       const a = delaunay.triangles[t];
       const b = delaunay.triangles[t + 1];
       const c = delaunay.triangles[t + 2];
-      const centLng = (points[a][0] + points[b][0] + points[c][0]) / 3;
+      // Antimeridian-safe centroid: unwrap lngB and lngC relative to lngA so that
+      // triangles straddling ±180° (e.g. Russia's eastern coast) get a correct
+      // geographic centroid. Without unwrapping, a triangle with vertices at
+      // +178°, −178°, −175° computes centroid = (178−178−175)/3 = −58° (Atlantic!),
+      // causing geoContains to reject it and leaving a seam hole at the antimeridian.
+      const lngA = points[a][0];
+      const lngB = points[b][0];
+      const lngC = points[c][0];
+      const unwrappedB = lngB - lngA > 180 ? lngB - 360 : lngB - lngA < -180 ? lngB + 360 : lngB;
+      const unwrappedC = lngC - lngA > 180 ? lngC - 360 : lngC - lngA < -180 ? lngC + 360 : lngC;
+      const rawCentLng = (lngA + unwrappedB + unwrappedC) / 3;
+      // Wrap back to [-180, 180] before passing to geoContains
+      const centLng = ((rawCentLng + 180) % 360 + 360) % 360 - 180;
       const centLat = (points[a][1] + points[b][1] + points[c][1]) / 3;
       if (geoContains(geoPolygon, [centLng, centLat])) {
         indices.push(a, b, c);


### PR DESCRIPTION
## Summary

Fixes Russia (and any other country whose polygon crosses the ±180° antimeridian) still rendering as a hollow ring after PR #52.

## Root Cause Chain

```
geoBounds(russiaPolygon) → inverted bounds (maxLng < minLng false positive)
  → getInteriorGeoPoints returns []
    → earcut fallback → SLERP-subdivided ±180° edge looks self-intersecting
      → earcut returns [] → triangulatePolygon → null → hollow ring
```

Russia's outer ring has vertices near ±180° on both sides (the antimeridian is Russia's eastern coastline). d3-geo's `geoBounds` interprets the CW ring as spanning eastward through the antimeridian and returns inverted bounds `[[27, 41], [−168, 82]]` where `maxLng < minLng`. The old guard `if (maxLng < minLng) return []` fired on this — correctly detecting the topology but incorrectly bailing out.

A secondary bug: the Delaunay centroid computation averaged raw longitudes without handling the ±180° discontinuity. A triangle at +178°/−178°/−175° computed centroid = −58° (Atlantic Ocean) → `geoContains` rejected it → seam hole at the antimeridian.

## Fixes

### Fix A — `getInteriorGeoPoints` (`geo.ts`)
Remove `geoBounds` dependency entirely. Scan outer ring vertices directly to compute bounds. Detect antimeridian crossing when `lngSpan > 180°`. For crossing polygons, generate two sub-grids:
- Western: `[minLngPositive .. 180)`
- Eastern: `(−180 .. maxLngNegative]`

Both filtered by `geoContains` which handles antimeridian correctly.

### Fix B — Delaunay centroid unwrapping (`geo.ts`)
Unwrap `lngB` and `lngC` relative to `lngA` before averaging:
```ts
const unwrappedB = lngB - lngA > 180 ? lngB - 360 : lngB - lngA < -180 ? lngB + 360 : lngB;
```
Wrap the raw centroid back to `[−180, 180]` before passing to `geoContains`.

## Changes

- `src/lib/utils/geo.ts` — remove `geoBounds` import + Fix A + Fix B
- `src/__tests__/utils/geo.test.ts` — 2 regression tests for Russia-like antimeridian ring

## Test Results

**145/145 tests passing** (was 144 before — 1 regression test added for `getInteriorGeoPoints`, 1 for `triangulatePolygon`).

Build: `✓ Compiled successfully`

## Visual QA Checklist

- [ ] Russia — solid fill, no hollow ring
- [ ] Fiji / Kiribati / Samoa — no regression
- [ ] USA / Canada — no regression
- [ ] Germany / France — no regression

Closes #53