### PR TITLE
feat(dashboard): UX improvements — progress ring, CTA, country total, card imagery

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -36,7 +36,7 @@
       "title": "Your Journey",
       "progress": "{discovered} / {total} Countries Found",
       "highScore": "Quiz High Score: {score} pts",
-      "viewPassport": "My Adventure Book"
+      "viewPassport": "Continue Adventure"
     },
     "exploreCard": {
       "title": "Explore the World",

--- a/messages/es.json
+++ b/messages/es.json
@@ -36,7 +36,7 @@
       "title": "Tu Viaje",
       "progress": "{discovered} / {total} Países Descubiertos",
       "highScore": "Puntuación récord: {score} pts",
-      "viewPassport": "Mi Libro de Aventuras"
+      "viewPassport": "Continuar Aventura"
     },
     "exploreCard": {
       "title": "Explora el Mundo",

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -5,7 +5,6 @@ import { useTranslations } from "next-intl";
 import { Link, useRouter } from "@/i18n/navigation";
 import { AppShell } from "@/components/layout/AppShell";
 import { Continent } from "@/data/types";
-import { Button } from "@/components/ui/Button";
 import { useCountries } from "@/lib/providers/CountriesProvider";
 import { useAuth } from "@/lib/providers/AuthProvider";
 
@@ -24,6 +23,11 @@ function DashboardContent() {
   const handleContinentSelect = (continent: Continent | null) => {
     if (continent) router.push(`/catalog?continent=${continent}`);
   };
+
+  const totalCountries = countries.length || 1;
+  const discoveredCount = progress?.discoveredCountries.length ?? 0;
+  const ringCircumference = 2 * Math.PI * 52;
+  const ringOffset = ringCircumference * (1 - Math.min(discoveredCount / totalCountries, 1));
 
   // Pick 4 countries daily — deterministic based on day-of-year (DAY_OF_YEAR computed at module load)
   const dailyCountries = useMemo(() => {
@@ -83,12 +87,39 @@ function DashboardContent() {
                 </div>
               </div>
             </div>
-            <div className="relative mt-8 h-64 w-full overflow-hidden bg-surface-container">
-              <div className="w-full h-full flex items-center justify-center text-on-surface-variant">
-                <span className="material-symbols-outlined text-8xl opacity-20">
+            <div className="relative mt-8 h-64 w-full overflow-hidden bg-gradient-to-br from-surface-container to-primary-container">
+              <svg
+                className="absolute inset-0 w-full h-full"
+                xmlns="http://www.w3.org/2000/svg"
+                aria-hidden="true"
+              >
+                <defs>
+                  <pattern id="dot-grid" x="0" y="0" width="20" height="20" patternUnits="userSpaceOnUse">
+                    <circle cx="2" cy="2" r="1.5" fill="#0052d0" opacity="0.25" />
+                  </pattern>
+                </defs>
+                <rect width="100%" height="100%" fill="url(#dot-grid)" />
+              </svg>
+              <div className="absolute inset-0 flex items-center justify-center">
+                <span
+                  className="material-symbols-outlined text-primary opacity-20 select-none"
+                  style={{ fontSize: "9rem", fontVariationSettings: "'FILL' 1" }}
+                >
                   public
                 </span>
               </div>
+              <span
+                className="material-symbols-outlined absolute top-4 right-10 text-primary opacity-10 select-none pointer-events-none"
+                style={{ fontSize: "4rem" }}
+              >
+                travel_explore
+              </span>
+              <span
+                className="material-symbols-outlined absolute bottom-4 left-8 text-primary opacity-10 select-none pointer-events-none"
+                style={{ fontSize: "3rem" }}
+              >
+                location_on
+              </span>
             </div>
           </Link>
 
@@ -96,31 +127,62 @@ function DashboardContent() {
           <div className="md:col-span-4 bg-tertiary-container text-on-tertiary-container rounded-xl p-8 flex flex-col justify-between shadow-ambient">
             <div>
               <h3 className="text-2xl font-bold mb-1">{t("journey.title")}</h3>
-              <p className="opacity-80">{t("journey.progress", { discovered: progress?.discoveredCountries.length ?? 0, total: 245 })}</p>
+              <p className="opacity-80">{t("journey.progress", { discovered: discoveredCount, total: countries.length })}</p>
               {(progress?.quizHighScore ?? 0) > 0 && (
                 <p className="text-sm opacity-70 mt-1">
                   {t("journey.highScore", { score: progress?.quizHighScore ?? 0 })}
                 </p>
               )}
             </div>
-            <div className="relative py-8 flex justify-center">
-              <div className="w-32 h-32 rounded-full bg-white/20 flex items-center justify-center">
-                <span
-                  className="material-symbols-outlined text-6xl"
-                  style={{ fontVariationSettings: "'FILL' 1" }}
+            <div className="relative py-4 flex justify-center">
+              <div className="relative w-32 h-32">
+                <svg
+                  width="128"
+                  height="128"
+                  viewBox="0 0 128 128"
+                  className="absolute inset-0"
                 >
-                  emoji_events
-                </span>
+                  <circle
+                    cx="64" cy="64" r="52"
+                    fill="none"
+                    stroke="white"
+                    strokeWidth="8"
+                    opacity={0.2}
+                  />
+                  <circle
+                    cx="64" cy="64" r="52"
+                    fill="none"
+                    stroke="white"
+                    strokeWidth="8"
+                    strokeLinecap="round"
+                    strokeDasharray={ringCircumference}
+                    strokeDashoffset={ringOffset}
+                    transform="rotate(-90 64 64)"
+                    style={{ transition: "stroke-dashoffset 0.6s ease" }}
+                  />
+                </svg>
+                <div className="absolute inset-0 flex items-center justify-center">
+                  <span
+                    className="material-symbols-outlined text-5xl"
+                    style={{ fontVariationSettings: "'FILL' 1" }}
+                  >
+                    emoji_events
+                  </span>
+                </div>
               </div>
             </div>
-            <Button
-              variant="ghost"
-              fullWidth
-              className="bg-on-tertiary-container text-tertiary-container hover:brightness-90"
-              disabled
+            <Link
+              href="/catalog"
+              className="w-full flex items-center justify-center gap-2 px-6 py-3 rounded-xl bg-on-tertiary-container text-tertiary-container font-bold hover:brightness-90 transition-bounce"
             >
+              <span
+                className="material-symbols-outlined text-base"
+                style={{ fontVariationSettings: "'FILL' 1" }}
+              >
+                explore
+              </span>
               {t("journey.viewPassport")}
-            </Button>
+            </Link>
           </div>
 
           {/* Explore the World */}
@@ -135,10 +197,25 @@ function DashboardContent() {
               </p>
             </div>
             <div className="z-10 self-start">
-              <span className="material-symbols-outlined text-primary text-6xl">
+              <span
+                className="material-symbols-outlined text-primary text-6xl"
+                style={{ fontVariationSettings: "'FILL' 1" }}
+              >
                 auto_stories
               </span>
             </div>
+            <span
+              className="material-symbols-outlined absolute -bottom-6 -right-6 text-primary opacity-[0.08] select-none pointer-events-none"
+              style={{ fontSize: "13rem" }}
+            >
+              luggage
+            </span>
+            <span
+              className="material-symbols-outlined absolute top-6 right-10 text-primary opacity-[0.06] select-none pointer-events-none"
+              style={{ fontSize: "5rem" }}
+            >
+              travel_explore
+            </span>
           </Link>
 
           {/* Play & Learn */}
@@ -153,10 +230,25 @@ function DashboardContent() {
               </p>
             </div>
             <div className="z-10 self-start">
-              <span className="material-symbols-outlined text-secondary text-6xl">
+              <span
+                className="material-symbols-outlined text-secondary text-6xl"
+                style={{ fontVariationSettings: "'FILL' 1" }}
+              >
                 videogame_asset
               </span>
             </div>
+            <span
+              className="material-symbols-outlined absolute -bottom-6 -right-6 text-secondary opacity-[0.08] select-none pointer-events-none"
+              style={{ fontSize: "13rem" }}
+            >
+              sports_esports
+            </span>
+            <span
+              className="material-symbols-outlined absolute top-6 right-10 text-secondary opacity-[0.06] select-none pointer-events-none"
+              style={{ fontSize: "5rem" }}
+            >
+              emoji_events
+            </span>
           </Link>
         </div>
 


### PR DESCRIPTION
Implements four dashboard fixes from issue #57: dynamic country total, SVG progress ring, active Continue Adventure CTA navigating to /catalog, and visual card imagery (gradient+dot-grid on map card; layered decorative icons on Explore and Play cards). Build passes 505 pages, zero errors.