### PR TITLE
feat(dashboard): visual refresh - real mini-map, flag mosaic, Unsplash photo, label fix

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -34,7 +34,7 @@
     },
     "journey": {
       "title": "Your Journey",
-      "progress": "{discovered} / {total} Countries Found",
+      "progress": "{discovered} / {total} Nations & Territories Found",
       "highScore": "Quiz High Score: {score} pts",
       "viewPassport": "Continue Adventure"
     },

--- a/messages/es.json
+++ b/messages/es.json
@@ -34,7 +34,7 @@
     },
     "journey": {
       "title": "Tu Viaje",
-      "progress": "{discovered} / {total} Países Descubiertos",
+      "progress": "{discovered} / {total} Naciones y Territorios",
       "highScore": "Puntuación récord: {score} pts",
       "viewPassport": "Continuar Aventura"
     },

--- a/next.config.ts
+++ b/next.config.ts
@@ -9,6 +9,11 @@ const nextConfig: NextConfig = {
         hostname: "flagcdn.com",
         pathname: "/**",
       },
+      {
+        protocol: "https",
+        hostname: "images.unsplash.com",
+        pathname: "/**",
+      },
     ],
   },
 };

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -1,12 +1,14 @@
 "use client";
 
 import { useMemo, Suspense } from "react";
+import Image from "next/image";
 import { useTranslations } from "next-intl";
 import { Link, useRouter } from "@/i18n/navigation";
 import { AppShell } from "@/components/layout/AppShell";
 import { Continent } from "@/data/types";
 import { useCountries } from "@/lib/providers/CountriesProvider";
 import { useAuth } from "@/lib/providers/AuthProvider";
+import { MiniMap } from "@/components/map/MiniMap";
 
 // Computed once at module load — stable within a session, changes on next page load each day
 const _now = Date.now();
@@ -77,49 +79,10 @@ function DashboardContent() {
                     {t("mapCard.subtitle")}
                   </p>
                 </div>
-                <div className="bg-primary-container p-4 rounded-full text-on-primary-container">
-                  <span
-                    className="material-symbols-outlined text-4xl"
-                    style={{ fontVariationSettings: "'FILL' 1" }}
-                  >
-                    explore
-                  </span>
-                </div>
               </div>
             </div>
-            <div className="relative mt-8 h-64 w-full overflow-hidden bg-gradient-to-br from-surface-container to-primary-container">
-              <svg
-                className="absolute inset-0 w-full h-full"
-                xmlns="http://www.w3.org/2000/svg"
-                aria-hidden="true"
-              >
-                <defs>
-                  <pattern id="dot-grid" x="0" y="0" width="20" height="20" patternUnits="userSpaceOnUse">
-                    <circle cx="2" cy="2" r="1.5" fill="#0052d0" opacity="0.25" />
-                  </pattern>
-                </defs>
-                <rect width="100%" height="100%" fill="url(#dot-grid)" />
-              </svg>
-              <div className="absolute inset-0 flex items-center justify-center">
-                <span
-                  className="material-symbols-outlined text-primary opacity-20 select-none"
-                  style={{ fontSize: "9rem", fontVariationSettings: "'FILL' 1" }}
-                >
-                  public
-                </span>
-              </div>
-              <span
-                className="material-symbols-outlined absolute top-4 right-10 text-primary opacity-10 select-none pointer-events-none"
-                style={{ fontSize: "4rem" }}
-              >
-                travel_explore
-              </span>
-              <span
-                className="material-symbols-outlined absolute bottom-4 left-8 text-primary opacity-10 select-none pointer-events-none"
-                style={{ fontSize: "3rem" }}
-              >
-                location_on
-              </span>
+            <div className="relative mt-8 h-64 w-full overflow-hidden">
+              <MiniMap />
             </div>
           </Link>
 
@@ -204,18 +167,17 @@ function DashboardContent() {
                 auto_stories
               </span>
             </div>
-            <span
-              className="material-symbols-outlined absolute -bottom-6 -right-6 text-primary opacity-[0.08] select-none pointer-events-none"
-              style={{ fontSize: "13rem" }}
-            >
-              luggage
-            </span>
-            <span
-              className="material-symbols-outlined absolute top-6 right-10 text-primary opacity-[0.06] select-none pointer-events-none"
-              style={{ fontSize: "5rem" }}
-            >
-              travel_explore
-            </span>
+            <div className="absolute bottom-0 right-0 grid grid-cols-4 gap-1 p-2 pointer-events-none select-none">
+              {["br","in","jp","ca","za","ng","au","mx","fr","ua","gb","ar"].map((code) => (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img
+                  key={code}
+                  src={`https://flagcdn.com/w80/${code}.png`}
+                  alt=""
+                  className="w-10 h-7 object-cover rounded shadow-sm"
+                />
+              ))}
+            </div>
           </Link>
 
           {/* Play & Learn */}
@@ -237,18 +199,15 @@ function DashboardContent() {
                 videogame_asset
               </span>
             </div>
-            <span
-              className="material-symbols-outlined absolute -bottom-6 -right-6 text-secondary opacity-[0.08] select-none pointer-events-none"
-              style={{ fontSize: "13rem" }}
-            >
-              sports_esports
-            </span>
-            <span
-              className="material-symbols-outlined absolute top-6 right-10 text-secondary opacity-[0.06] select-none pointer-events-none"
-              style={{ fontSize: "5rem" }}
-            >
-              emoji_events
-            </span>
+            <div className="absolute bottom-0 right-0 w-48 h-40 overflow-hidden rounded-tl-xl pointer-events-none">
+              <Image
+                src="https://images.unsplash.com/photo-1606092195730-5d7b9af1efc5?auto=format&fit=crop&w=400&q=80"
+                alt=""
+                fill
+                className="object-cover opacity-80"
+                sizes="192px"
+              />
+            </div>
           </Link>
         </div>
 

--- a/src/components/map/MiniMap.tsx
+++ b/src/components/map/MiniMap.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import * as topojson from "topojson-client";
+import { geoMercator, geoPath } from "d3-geo";
+import type { Topology, GeometryCollection } from "topojson-specification";
+import type { Feature, Polygon, MultiPolygon } from "geojson";
+import { getCountryFlagCode } from "@/lib/utils/geo";
+import { countriesData } from "@/data/countries";
+import type { Continent } from "@/data/types";
+
+const CONTINENT_COLORS: Record<Continent, string> = {
+  Africa: "#4CAF50",
+  Asia: "#FF6B6B",
+  Europe: "#5C6BC0",
+  "North America": "#FFB74D",
+  "South America": "#26A69A",
+  Oceania: "#AB47BC",
+};
+
+const OCEAN_COLOR = "#c8d8e8";
+const UNKNOWN_COLOR = "#d8d8d8";
+
+const WIDTH = 568;
+const HEIGHT = 256;
+
+const projection = geoMercator()
+  .center([15, 52])
+  .scale(520)
+  .translate([WIDTH / 2, HEIGHT / 2]);
+
+const pathGenerator = geoPath(projection);
+
+type GeoFeature = Feature<Polygon | MultiPolygon>;
+
+export function MiniMap() {
+  const [features, setFeatures] = useState<GeoFeature[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch("/geo/world-110m.json")
+      .then((r) => r.json())
+      .then((topology: Topology<{ countries: GeometryCollection }>) => {
+        if (cancelled) return;
+        const { features: f } = topojson.feature(
+          topology,
+          topology.objects.countries,
+        ) as unknown as { features: GeoFeature[] };
+        setFeatures(f);
+        setLoading(false);
+      })
+      .catch(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="w-full h-full flex items-center justify-center bg-surface-container">
+        <span
+          className="material-symbols-outlined text-5xl text-on-surface-variant opacity-30 animate-pulse"
+          style={{ fontVariationSettings: "'FILL' 1" }}
+        >
+          public
+        </span>
+      </div>
+    );
+  }
+
+  return (
+    <svg
+      viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
+      width="100%"
+      height="100%"
+      aria-hidden="true"
+      style={{ display: "block" }}
+    >
+      <rect width={WIDTH} height={HEIGHT} fill={OCEAN_COLOR} />
+      {features.map((feature, i) => {
+        const flagCode = getCountryFlagCode(feature);
+        const entry = flagCode
+          ? countriesData.find((c) => c.flagCode === flagCode)
+          : undefined;
+        const fill = entry?.continent
+          ? CONTINENT_COLORS[entry.continent as Continent]
+          : UNKNOWN_COLOR;
+        const d = pathGenerator(feature);
+        if (!d) return null;
+        return (
+          <path
+            key={i}
+            d={d}
+            fill={fill}
+            stroke="white"
+            strokeWidth={0.4}
+            opacity={0.9}
+          />
+        );
+      })}
+    </svg>
+  );
+}


### PR DESCRIPTION
## Summary
Round 2 dashboard visual improvements replacing placeholder imagery with real content.

## Changes

### MiniMap component (new)
- `src/components/map/MiniMap.tsx` — "use client" SVG using `d3-geo` + `topojson-client`
- Fetches `/geo/world-110m.json` (lighter 100KB file)
- Mercator projection centred on Europe (center 15,52 — scale 520)
- Countries coloured by continent matching the 3D globe CONTINENT_COLORS
- Loading skeleton while topology loads

### Map card header
- Removed compass icon div from the right-hand side of the card header

### Explore card
- Replaced oversized translucent icon decorations with a real 4x3 flag mosaic (12 countries via flagcdn.com)

### Play card
- Replaced translucent icon decorations with an Unsplash game photo (next/image, fill layout)
- Added images.unsplash.com to next.config.ts remote patterns

### Label clarity
- EN: "Countries Found" -> "Nations & Territories Found"
- ES: "Paises Descubiertos" -> "Naciones y Territorios"

## Verification
- Build: 505 pages, zero errors
- Tests: 145/145 passing

Closes #59
