### PR TITLE
feat(sidebar): sticky sidebar, visual polish, hover animations

### DIFF
--- a/src/components/catalog/ContinentFilter.tsx
+++ b/src/components/catalog/ContinentFilter.tsx
@@ -21,7 +21,7 @@ export function ContinentFilter({ active, onSelect }: ContinentFilterProps) {
             key={c.name}
             onClick={() => onSelect(isActive ? null : c.name)}
             className={`
-              flex items-center gap-3 mx-4 px-4 py-3 rounded-full font-semibold
+              group flex items-center gap-3 mx-4 px-4 py-3 rounded-full font-semibold
               transition-all duration-300
               ${
                 isActive
@@ -30,7 +30,7 @@ export function ContinentFilter({ active, onSelect }: ContinentFilterProps) {
               }
             `}
           >
-            <span className="material-symbols-outlined">{c.icon}</span>
+            <span className="material-symbols-outlined transition-transform duration-150 group-hover:scale-110">{c.icon}</span>
             {t(c.name)}
           </button>
         );

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -29,7 +29,7 @@ function AppShellInner({
   return (
     <div className="min-h-screen bg-surface">
       <TopNav searchQuery={searchQuery} onSearchChange={onSearchChange} />
-      <div className="flex max-w-screen-2xl mx-auto">
+      <div className="flex items-start max-w-screen-2xl mx-auto">
         {showSidebar && (
           <SideNav
             activeContinent={activeContinent}

--- a/src/components/layout/SideNav.tsx
+++ b/src/components/layout/SideNav.tsx
@@ -18,7 +18,7 @@ export function SideNav({
   const t = useTranslations("sidebar");
 
   return (
-    <aside className="hidden lg:flex flex-col w-72 py-8 gap-2 bg-surface-container-lowest shadow-ambient rounded-r-xl">
+    <aside className="hidden lg:flex flex-col w-72 py-8 gap-2 bg-surface-container-lowest shadow-ambient rounded-xl sticky top-16 self-start h-[calc(100vh-4rem)] overflow-y-auto mt-2 mb-2">
       <div className="px-8 mb-6">
         <h2 className="text-xl font-bold text-primary">{t("title")}</h2>
         <p className="text-on-surface-variant text-sm font-semibold">
@@ -29,10 +29,10 @@ export function SideNav({
       <ContinentFilter active={activeContinent} onSelect={onSelectContinent} />
 
       <div className="mt-auto px-6 pb-8">
-        <Link href="/games/guess-the-flag">
+        <Link href="/games/guess-the-flag" className="group/cta">
           <Button variant="tertiary" fullWidth>
             <span className="flex items-center justify-center gap-2">
-              <span className="material-symbols-outlined">auto_awesome</span>
+              <span className="material-symbols-outlined transition-transform duration-150 group-hover/cta:scale-110">auto_awesome</span>
               {t("dailyChallenge")}
             </span>
           </Button>


### PR DESCRIPTION
## Summary
Closes #63

## Changes
- **`AppShell.tsx`**: added `items-start` to flex row — required for `sticky` to work inside a flex container
- **`SideNav.tsx`**: sidebar is now `sticky top-16`, capped to viewport height (`h-[calc(100vh-4rem)]`), internal scroll with `overflow-y-auto`, rounded on all four corners (`rounded-xl`), 8px top/bottom margin (`mt-2 mb-2`)
- **`ContinentFilter.tsx`**: continent icons animate with `scale-110` on hover (150ms, via `group` pattern)
- **`SideNav.tsx`**: CTA Daily Challenge `auto_awesome` icon also animates on hover (named `group/cta`)

## Testing
- ✅ 145/145 tests passing
- ✅ Lint clean (no new errors in changed files)
- ✅ Mobile unaffected: sidebar is `hidden` below `lg`, BottomNav unchanged