### PR TITLE
fix(sidebar): switch to app-shell pattern for reliable fixed sidebar

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -124,4 +124,13 @@
     transition-timing-function: var(--ease-back-out);
     transition-duration: 200ms;
   }
+
+  .scrollbar-hidden {
+    scrollbar-width: none; /* Firefox */
+    -ms-overflow-style: none; /* IE/Edge */
+  }
+
+  .scrollbar-hidden::-webkit-scrollbar {
+    display: none; /* Chrome/Safari */
+  }
 }

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -37,7 +37,7 @@ function AppShellInner({
               onSelectContinent={handleContinentSelect}
             />
           )}
-          <main className="flex-1 overflow-y-auto p-6 md:p-12 pb-24 lg:pb-12">
+          <main className="flex-1 overflow-y-auto scrollbar-hidden p-6 md:p-12 pb-24 lg:pb-12">
             {children}
           </main>
         </div>

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -27,18 +27,20 @@ function AppShellInner({
   const handleContinentSelect = onContinentSelect ?? setContinent;
 
   return (
-    <div className="min-h-screen bg-surface">
+    <div className="h-screen flex flex-col bg-surface">
       <TopNav searchQuery={searchQuery} onSearchChange={onSearchChange} />
-      <div className="flex items-start max-w-screen-2xl mx-auto">
-        {showSidebar && (
-          <SideNav
-            activeContinent={activeContinent}
-            onSelectContinent={handleContinentSelect}
-          />
-        )}
-        <main className="flex-1 p-6 md:p-12 pb-24 lg:pb-12">
-          {children}
-        </main>
+      <div className="flex-1 overflow-hidden">
+        <div className="flex h-full max-w-screen-2xl mx-auto">
+          {showSidebar && (
+            <SideNav
+              activeContinent={activeContinent}
+              onSelectContinent={handleContinentSelect}
+            />
+          )}
+          <main className="flex-1 overflow-y-auto p-6 md:p-12 pb-24 lg:pb-12">
+            {children}
+          </main>
+        </div>
       </div>
       <BottomNav />
     </div>

--- a/src/components/layout/SideNav.tsx
+++ b/src/components/layout/SideNav.tsx
@@ -18,7 +18,7 @@ export function SideNav({
   const t = useTranslations("sidebar");
 
   return (
-    <aside className="hidden lg:flex flex-col w-72 py-8 gap-2 bg-surface-container-lowest shadow-ambient rounded-xl sticky top-16 self-start h-[calc(100vh-4rem)] overflow-y-auto mt-2 mb-2">
+    <aside className="hidden lg:flex flex-col w-72 py-8 gap-2 bg-surface-container-lowest shadow-ambient rounded-xl overflow-y-auto my-4">
       <div className="px-8 mb-6">
         <h2 className="text-xl font-bold text-primary">{t("title")}</h2>
         <p className="text-on-surface-variant text-sm font-semibold">


### PR DESCRIPTION
## Problem
Closes #65

The `position: sticky` sidebar was scrolling with the page. Root cause: sticky requires the containing block to be taller than the sticky element. The sidebar (`h-[calc(100vh-4rem)]`) was often as tall as (or taller than) the flex row container, so sticky never engaged. Also has known cross-browser quirks inside flex containers.

## Fix: App-Shell Pattern

Instead of relying on CSS sticky tricks, the layout now uses the standard **app-shell pattern**:

```
h-screen flex flex-col          ← outer: viewport-height container
  TopNav                        ← always at top, no scroll
  flex-1 overflow-hidden        ← fills remaining height
    flex h-full max-w-screen-2xl
      SideNav                   ← sits still, never scrolls
      main overflow-y-auto      ← ONLY this scrolls
  BottomNav                     ← fixed bottom, unaffected
```

The sidebar stays fixed **naturally** — it's a flex sibling of the scrolling content, not a sticky element within it.

## Also
- Sidebar margin increased from `my-2` → `my-4` (more separation from TopNav and bottom edge)
- Removed `sticky top-16 self-start h-[calc(100vh-4rem)]` from `<aside>`
- Removed `items-start` from AppShell flex row (no longer needed)

## Testing
- ✅ 145/145 tests passing
- ✅ No new lint errors in changed files