### PR TITLE
fix(i18n): guard auth loading state to prevent stale empty states on locale switch

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -19,7 +19,7 @@ const DAY_OF_YEAR = Math.floor(
 function DashboardContent() {
   const t = useTranslations("home");
   const { countries } = useCountries();
-  const { progress, isAnonymous, nickname } = useAuth();
+  const { progress, isAnonymous, nickname, loading: authLoading } = useAuth();
   const router = useRouter();
 
   const handleContinentSelect = (continent: Continent | null) => {
@@ -85,7 +85,7 @@ function DashboardContent() {
             <div>
               <h3 className="text-2xl font-bold mb-1">{t("journey.title")}</h3>
               <p className="opacity-80">{t("journey.progress", { discovered: discoveredCount, total: countries.length })}</p>
-              {(progress?.quizHighScore ?? 0) > 0 && (
+              {!authLoading && (progress?.quizHighScore ?? 0) > 0 && (
                 <p className="text-sm opacity-70 mt-1">
                   {t("journey.highScore", { score: progress?.quizHighScore ?? 0 })}
                 </p>

--- a/src/components/auth/AuthModal.tsx
+++ b/src/components/auth/AuthModal.tsx
@@ -11,7 +11,7 @@ type AuthModalProps = {
 
 export function AuthModal({ isOpen, onClose }: AuthModalProps) {
   const t = useTranslations("auth");
-  const { signInWithGoogle, nickname, progress } = useAuth();
+  const { signInWithGoogle, nickname, progress, loading: authLoading } = useAuth();
   const [isSigningIn, setIsSigningIn] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -82,7 +82,7 @@ export function AuthModal({ isOpen, onClose }: AuthModalProps) {
           <p className="text-xs text-on-surface-variant mb-1">{t("anonymousLabel")}</p>
           <p className="font-bold text-on-surface">{nickname}</p>
           <p className="text-xs text-on-surface-variant mt-1">
-            {t("progressSummary", { countries: countriesCount, score: highScore })}
+            {authLoading ? "\u00a0" : t("progressSummary", { countries: countriesCount, score: highScore })}
           </p>
         </div>
 

--- a/src/components/auth/ProfileDialog.tsx
+++ b/src/components/auth/ProfileDialog.tsx
@@ -38,7 +38,7 @@ export function ProfileDialog({ isOpen, onClose }: Props) {
   const tTiers = useTranslations("leaderboard.rankTiers");
   const tAuth = useTranslations("auth");
   const tQuiz = useTranslations("quiz");
-  const { nickname, avatarSeed, progress, updateAvatarSeed, signOut, lastGameInsignias } = useAuth();
+  const { nickname, avatarSeed, progress, loading: authLoading, updateAvatarSeed, signOut, lastGameInsignias } = useAuth();
 
   const [changingAvatar, setChangingAvatar] = useState(false);
   const [pendingSeed, setPendingSeed] = useState(avatarSeed);
@@ -230,13 +230,13 @@ export function ProfileDialog({ isOpen, onClose }: Props) {
         <div className="grid grid-cols-2 gap-2 text-center">
           <div className="bg-surface-variant rounded-2xl py-3">
             <p className="text-xl font-bold text-on-surface">
-              {progress?.discoveredCountries.length ?? 0}
+              {authLoading ? "—" : (progress?.discoveredCountries.length ?? 0)}
             </p>
             <p className="text-xs text-on-surface-variant">{t("flagsFound")}</p>
           </div>
           <div className="bg-surface-variant rounded-2xl py-3">
             <p className="text-xl font-bold text-on-surface">
-              {progress?.quizGamesPlayed ?? 0}
+              {authLoading ? "—" : (progress?.quizGamesPlayed ?? 0)}
             </p>
             <p className="text-xs text-on-surface-variant">{t("gamesPlayed")}</p>
           </div>
@@ -245,7 +245,7 @@ export function ProfileDialog({ isOpen, onClose }: Props) {
         {/* Badges */}
         <div className="space-y-2">
           <p className="text-sm font-semibold text-on-surface">{t("badgesTitle")}</p>
-          {earnedBadgeIds.length === 0 ? (
+          {!authLoading && earnedBadgeIds.length === 0 ? (
             <div className="flex flex-col items-center gap-2 py-4 text-center">
               <span
                 className="material-symbols-outlined text-on-surface-variant opacity-30 text-4xl"

--- a/src/components/games/FlagQuiz.tsx
+++ b/src/components/games/FlagQuiz.tsx
@@ -61,7 +61,7 @@ export function FlagQuiz({ pool, onGameOver }: FlagQuizProps) {
     const correctInGame = Math.round(state.score / POINTS_PER_CORRECT);
     const multiplier = SCORE_MULTIPLIERS[state.difficulty];
     const computed = state.score * multiplier;
-    const isRecord = computed > 0 && computed > (progress?.quizHighScore ?? 0);
+    const isRecord = !!progress && computed > 0 && computed > (progress.quizHighScore ?? 0);
     const gameResult = {
       difficulty: state.difficulty,
       livesRemaining: state.lives,

--- a/src/components/leaderboard/WorldRankingsContent.tsx
+++ b/src/components/leaderboard/WorldRankingsContent.tsx
@@ -18,7 +18,7 @@ const PAGE_SIZE = 10;
 
 export function WorldRankingsContent() {
   const t = useTranslations("leaderboard");
-  const { progress, uid } = useAuth();
+  const { progress, uid, loading: authLoading } = useAuth();
 
   const [topEntries, setTopEntries] = useState<LeaderboardEntry[]>([]);
   const [listEntries, setListEntries] = useState<LeaderboardEntry[]>([]);
@@ -34,6 +34,7 @@ export function WorldRankingsContent() {
 
   // Initial load
   useEffect(() => {
+    if (authLoading) return;
     async function load() {
       setLoading(true);
       try {
@@ -64,7 +65,7 @@ export function WorldRankingsContent() {
       }
     }
     void load();
-  }, [highScore]);
+  }, [highScore, authLoading]);
 
   const handleLoadMore = useCallback(async () => {
     if (loadingMore || !hasMore || lastScore === undefined) return;
@@ -81,7 +82,7 @@ export function WorldRankingsContent() {
     }
   }, [loadingMore, hasMore, lastScore]);
 
-  if (loading) {
+  if (authLoading || loading) {
     return (
       <div className="flex items-center justify-center py-32">
         <span className="material-symbols-outlined text-primary text-4xl animate-spin">


### PR DESCRIPTION
Closes #71

## Root Cause

AuthProvider lives inside [locale]/layout.tsx. Every locale switch remounts the layout tree including AuthProvider. During remount, loading=true and progress=null briefly, before Firebase auth re-establishes the session.

Components that ignored useAuth().loading used progress?.quizHighScore ?? 0 (= 0) and rendered wrong empty states.

## Changes

### HIGH — Production bug (leaderboard)
- WorldRankingsContent: add authLoading guard to useEffect deps + render path, preventing PersonalProgressCard from receiving score=0 during locale transitions

### MEDIUM — Other affected components
- Dashboard: guard quizHighScore conditional render with !authLoading
- FlagQuiz: guard isRecord check with !!progress to prevent false record banner
- ProfileDialog: show dash for stats and suppress no-badges empty state while loading
- AuthModal: show blank placeholder for progress summary while loading

## Pattern
Follows MapPage.tsx and OnboardingGuard.tsx which correctly guard on useAuth().loading.

## Testing
- npm test: 145/145 passed
- npm run build: clean