### PR TITLE
fix(i18n): move AuthProvider to root layout to prevent remount on locale switch

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -4,7 +4,6 @@ import { Plus_Jakarta_Sans } from "next/font/google";
 import { notFound } from "next/navigation";
 import { routing } from "@/i18n/routing";
 import { CountriesProvider } from "@/lib/providers/CountriesProvider";
-import { AuthProvider } from "@/lib/providers/AuthProvider";
 import { OnboardingGuard } from "@/components/auth/OnboardingGuard";
 import "../globals.css";
 
@@ -53,10 +52,8 @@ export default async function LocaleLayout({
       <body className="font-sans">
         <NextIntlClientProvider messages={messages}>
           <CountriesProvider>
-            <AuthProvider>
-              <OnboardingGuard />
-              {children}
-            </AuthProvider>
+            <OnboardingGuard />
+            {children}
           </CountriesProvider>
         </NextIntlClientProvider>
       </body>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { AuthProvider } from "@/lib/providers/AuthProvider";
 
 export const metadata: Metadata = {
   title: "Explorer's Atlas",
@@ -11,5 +12,5 @@ export default function RootLayout({
 }: {
   children: React.ReactNode;
 }) {
-  return children;
+  return <AuthProvider>{children}</AuthProvider>;
 }


### PR DESCRIPTION
Fixes #73. Also fixes regression from #72.

## Root Cause

`AuthProvider` was inside `[locale]/layout.tsx`. Every locale switch remounts it, resetting `loading=true` and `progress=null`. This caused two bugs:

1. **Stands/podium disappear on language switch** (regression from #72): The `authLoading || loading` render gate hid the entire leaderboard during every remount cycle.
2. **"Play your first game" shows for ranked users**: `highScore=0` during the remount transition could reach the PersonalProgressCard before auth settled.

## Fix

Move `AuthProvider` up to `app/layout.tsx` (above the `[locale]` segment). Two file changes:

- **`app/layout.tsx`**: Wrap `children` with `AuthProvider`
- **`app/[locale]/layout.tsx`**: Remove `AuthProvider` import and wrapper

`AuthProvider` has no i18n or locale dependencies (no `useTranslations`, no `useLocale`) — it only communicates with Firebase. At the root level it persists across all locale navigations. `OnboardingGuard` remains in `[locale]/layout.tsx` and continues to receive `AuthContext` via React context propagation since `AuthProvider` is now an ancestor.

## Effect

- `authLoading` never toggles on locale switch → leaderboard stays visible
- `progress` / `highScore` never reset on locale switch → correct rank displayed
- `authLoading` guards added in #72 (dashboard, FlagQuiz, ProfileDialog, AuthModal) remain valid for initial page load only

## Testing

- 145/145 tests pass
- Build clean