### PR TITLE
perf(map): fix globe slow initial load and re-init on navigation

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -207,6 +207,7 @@
     "disableHoverPreview": "Disable hover preview",
     "geolocate": "Find my location",
     "reset": "Reset view",
-    "geolocationError": "Could not detect your location"
+    "geolocationError": "Could not detect your location",
+    "loadingCountries": "Loading countries…"
   }
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -207,6 +207,7 @@
     "disableHoverPreview": "Desactivar vista previa al pasar",
     "geolocate": "Encontrar mi ubicación",
     "reset": "Restablecer vista",
-    "geolocationError": "No se pudo detectar tu ubicación"
+    "geolocationError": "No se pudo detectar tu ubicación",
+    "loadingCountries": "Cargando países…"
   }
 }

--- a/src/__tests__/hooks/useGlobeData.test.ts
+++ b/src/__tests__/hooks/useGlobeData.test.ts
@@ -15,7 +15,7 @@ const mockFeature = {
     coordinates: [[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]],
   },
   properties: {},
-} as any;
+} as unknown as import("geojson").Feature<import("geojson").Polygon | import("geojson").MultiPolygon>;
 
 vi.mock("@/lib/utils/geo", () => ({
   loadLowResTopology: vi.fn(),
@@ -40,7 +40,7 @@ beforeEach(() => {
   vi.mocked(geoModule.loadWorldTopology).mockResolvedValue([mockFeature]);
   vi.mocked(geoModule.buildCountryGeometry).mockReturnValue({
     isBufferGeometry: true,
-  } as any);
+  } as unknown as import("three").BufferGeometry);
   vi.mocked(geoModule.getCountryFlagCode).mockReturnValue("us");
   vi.mocked(geoModule.latLngToCartesian).mockReturnValue([0, 0, 1]);
 });

--- a/src/__tests__/hooks/useGlobeData.test.ts
+++ b/src/__tests__/hooks/useGlobeData.test.ts
@@ -71,11 +71,13 @@ describe("useGlobeData", () => {
   it("sets upgrading=false after hi-res load completes", async () => {
     const { result } = renderHook(() => useGlobeData());
 
+    // Wait for full load cycle: loading=false AND upgrading=false simultaneously.
+    // (upgrading starts false in initial state, so we must not early-exit before
+    // the effect runs — waiting for loading===false guards against that.)
     await waitFor(() => {
+      expect(result.current.loading).toBe(false);
       expect(result.current.upgrading).toBe(false);
     });
-
-    expect(result.current.loading).toBe(false);
   });
 
   it("countries is non-empty after low-res load", async () => {

--- a/src/__tests__/hooks/useGlobeData.test.ts
+++ b/src/__tests__/hooks/useGlobeData.test.ts
@@ -92,4 +92,26 @@ describe("useGlobeData", () => {
 
     expect(result.current.countries[0].flagCode).toBe("us");
   });
+
+  it("returns cached data immediately when hi-res cache is warm", async () => {
+    // First, do a full load to warm both caches
+    const { result: r1, unmount: u1 } = renderHook(() => useGlobeData());
+    await waitFor(() => expect(r1.current.upgrading).toBe(false));
+    u1();
+
+    // Now reset mock call counts (but NOT the module cache — that's the whole point)
+    vi.clearAllMocks();
+
+    // Re-mount — should get cached data with no fetches
+    const { result: r2 } = renderHook(() => useGlobeData());
+
+    // Immediately (synchronously) has correct state — no loading, no upgrading
+    expect(r2.current.loading).toBe(false);
+    expect(r2.current.upgrading).toBe(false);
+    expect(r2.current.countries.length).toBeGreaterThan(0);
+
+    // Geo functions were never called again
+    expect(geoModule.loadLowResTopology).not.toHaveBeenCalled();
+    expect(geoModule.loadWorldTopology).not.toHaveBeenCalled();
+  });
 });

--- a/src/__tests__/hooks/useGlobeData.test.ts
+++ b/src/__tests__/hooks/useGlobeData.test.ts
@@ -1,0 +1,95 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  useGlobeData,
+  _resetGlobeDataCacheForTesting,
+} from "@/lib/hooks/useGlobeData";
+import * as geoModule from "@/lib/utils/geo";
+
+// Minimal GeoJSON feature for testing
+const mockFeature = {
+  type: "Feature",
+  id: "840",
+  geometry: {
+    type: "Polygon",
+    coordinates: [[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]],
+  },
+  properties: {},
+} as any;
+
+vi.mock("@/lib/utils/geo", () => ({
+  loadLowResTopology: vi.fn(),
+  loadWorldTopology: vi.fn(),
+  buildCountryGeometry: vi.fn(),
+  getCountryFlagCode: vi.fn(),
+  latLngToCartesian: vi.fn(),
+  _resetTopologyCacheForTesting: vi.fn(),
+  _resetLowResTopologyCacheForTesting: vi.fn(),
+}));
+
+vi.mock("@/data/countries", () => ({
+  countriesData: [
+    { slug: "united-states", flagCode: "us", continent: "North America" },
+  ],
+}));
+
+beforeEach(() => {
+  _resetGlobeDataCacheForTesting();
+  vi.clearAllMocks();
+  vi.mocked(geoModule.loadLowResTopology).mockResolvedValue([mockFeature]);
+  vi.mocked(geoModule.loadWorldTopology).mockResolvedValue([mockFeature]);
+  vi.mocked(geoModule.buildCountryGeometry).mockReturnValue({
+    isBufferGeometry: true,
+  } as any);
+  vi.mocked(geoModule.getCountryFlagCode).mockReturnValue("us");
+  vi.mocked(geoModule.latLngToCartesian).mockReturnValue([0, 0, 1]);
+});
+
+describe("useGlobeData", () => {
+  it("starts with loading=true when nothing is cached", () => {
+    const { result } = renderHook(() => useGlobeData());
+    expect(result.current.loading).toBe(true);
+    expect(result.current.upgrading).toBe(false);
+    expect(result.current.countries).toEqual([]);
+  });
+
+  it("sets loading=false and upgrading=true after low-res load", async () => {
+    // Delay hi-res so we can observe the intermediate state
+    vi.mocked(geoModule.loadWorldTopology).mockImplementation(
+      () => new Promise(() => {}), // never resolves
+    );
+
+    const { result } = renderHook(() => useGlobeData());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.upgrading).toBe(true);
+  });
+
+  it("sets upgrading=false after hi-res load completes", async () => {
+    const { result } = renderHook(() => useGlobeData());
+
+    await waitFor(() => {
+      expect(result.current.upgrading).toBe(false);
+    });
+
+    expect(result.current.loading).toBe(false);
+  });
+
+  it("countries is non-empty after low-res load", async () => {
+    // Delay hi-res so we observe state after stage 1
+    vi.mocked(geoModule.loadWorldTopology).mockImplementation(
+      () => new Promise(() => {}),
+    );
+
+    const { result } = renderHook(() => useGlobeData());
+
+    await waitFor(() => {
+      expect(result.current.countries.length).toBeGreaterThan(0);
+    });
+
+    expect(result.current.countries[0].flagCode).toBe("us");
+  });
+});

--- a/src/__tests__/utils/geo.test.ts
+++ b/src/__tests__/utils/geo.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import {
   latLngToCartesian,
   computeCentroid,
@@ -8,6 +8,7 @@ import {
   triangulatePolygon,
   getInteriorGeoPoints,
   loadWorldTopology,
+  _resetTopologyCacheForTesting,
 } from "@/lib/utils/geo";
 import type { Feature, Position } from "geojson";
 
@@ -331,12 +332,19 @@ describe("triangulatePolygon — antimeridian regression", () => {
 // loadWorldTopology — module-level cache
 // ---------------------------------------------------------------------------
 
-describe('loadWorldTopology', () => {
-  it('returns the same object reference on repeated calls (cache)', async () => {
-    vi.spyOn(global, 'fetch').mockResolvedValue({
+describe("loadWorldTopology", () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+    _resetTopologyCacheForTesting();
+  });
+
+  it("returns the same object reference on repeated calls (cache)", async () => {
+    fetchSpy = vi.spyOn(global, "fetch").mockResolvedValue({
       json: async () => ({
-        type: 'Topology',
-        objects: { countries: { type: 'GeometryCollection', geometries: [] } },
+        type: "Topology",
+        objects: { countries: { type: "GeometryCollection", geometries: [] } },
         arcs: [],
       }),
     } as unknown as Response);
@@ -345,9 +353,8 @@ describe('loadWorldTopology', () => {
     const result2 = await loadWorldTopology();
     const result3 = await loadWorldTopology();
 
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
     expect(result2).toBe(result1);
     expect(result3).toBe(result1);
-
-    vi.restoreAllMocks();
   });
 });

--- a/src/__tests__/utils/geo.test.ts
+++ b/src/__tests__/utils/geo.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import {
   latLngToCartesian,
   computeCentroid,
@@ -7,6 +7,7 @@ import {
   subdivideRing,
   triangulatePolygon,
   getInteriorGeoPoints,
+  loadWorldTopology,
 } from "@/lib/utils/geo";
 import type { Feature, Position } from "geojson";
 
@@ -323,5 +324,30 @@ describe("triangulatePolygon — antimeridian regression", () => {
     expect(result).not.toBeNull();
     expect(result!.positions.length).toBeGreaterThan(0);
     expect(result!.indices.length).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// loadWorldTopology — module-level cache
+// ---------------------------------------------------------------------------
+
+describe('loadWorldTopology', () => {
+  it('returns the same object reference on repeated calls (cache)', async () => {
+    vi.spyOn(global, 'fetch').mockResolvedValue({
+      json: async () => ({
+        type: 'Topology',
+        objects: { countries: { type: 'GeometryCollection', geometries: [] } },
+        arcs: [],
+      }),
+    } as unknown as Response);
+
+    const result1 = await loadWorldTopology();
+    const result2 = await loadWorldTopology();
+    const result3 = await loadWorldTopology();
+
+    expect(result2).toBe(result1);
+    expect(result3).toBe(result1);
+
+    vi.restoreAllMocks();
   });
 });

--- a/src/components/map/CountryLabels.tsx
+++ b/src/components/map/CountryLabels.tsx
@@ -1,4 +1,4 @@
-import { useMemo, type RefObject } from "react";
+import { memo, useMemo, type RefObject } from "react";
 import { Html } from "@react-three/drei";
 import type { ProcessedCountry } from "@/lib/hooks/useGlobeData";
 import { countriesData } from "@/data/countries";
@@ -12,7 +12,7 @@ type CountryLabelsProps = {
   sphereRef: RefObject<THREE.Mesh | null>;
 };
 
-export function CountryLabels({ countries, visible, locale, sphereRef }: CountryLabelsProps) {
+function CountryLabelsImpl({ countries, visible, locale, sphereRef }: CountryLabelsProps) {
 
   const nameBySlug = useMemo(
     () => new Map(countriesData.map((c) => [c.slug, c.translations[locale].name])),
@@ -43,3 +43,4 @@ export function CountryLabels({ countries, visible, locale, sphereRef }: Country
     </>
   );
 }
+export const CountryLabels = memo(CountryLabelsImpl);

--- a/src/components/map/CountryMeshes.tsx
+++ b/src/components/map/CountryMeshes.tsx
@@ -1,3 +1,4 @@
+import { memo } from "react";
 import * as THREE from "three";
 import type { ThreeEvent } from "@react-three/fiber";
 import type { ProcessedCountry } from "@/lib/hooks/useGlobeData";
@@ -16,6 +17,7 @@ const UNDISCOVERED_COLOR = "#C0C0C0";
 
 type CountryMeshesProps = {
   countries: ProcessedCountry[];
+  upgrading?: boolean;
   discoveredSlugs: string[];
   onCountrySelect?: (slug: string) => void;
   mode: "realistic" | "political";
@@ -23,8 +25,9 @@ type CountryMeshesProps = {
   onCountryHover?: (slug: string | null) => void;
 };
 
-export function CountryMeshes({
+function CountryMeshesImpl({
   countries,
+  upgrading: _upgrading,
   discoveredSlugs,
   onCountrySelect,
   mode,
@@ -84,3 +87,4 @@ export function CountryMeshes({
     </>
   );
 }
+export const CountryMeshes = memo(CountryMeshesImpl);

--- a/src/components/map/Globe.tsx
+++ b/src/components/map/Globe.tsx
@@ -2,10 +2,12 @@
 
 import { Suspense, lazy, useState, useRef, useEffect, useMemo } from "react";
 import { Canvas } from "@react-three/fiber";
+import { Html } from "@react-three/drei";
 import { useLocale, useTranslations } from "next-intl";
 import { GlobeControls } from "./GlobeControls";
 import { CountryPopup } from "./CountryPopup";
 import { countriesData } from "@/data/countries";
+import { useGlobeData } from "@/lib/hooks/useGlobeData";
 import type { Locale } from "@/data/types";
 import type { RootState } from "@react-three/fiber";
 
@@ -22,6 +24,7 @@ type GlobeProps = {
 };
 
 export function Globe({ discoveredSlugs, onCountrySelect, discoverCountry }: GlobeProps) {
+  const { countries, loading, upgrading } = useGlobeData();
   const [showLabels, setShowLabels] = useState(false);
   const [isDaylight, setIsDaylight] = useState(false);
   const [autoRotate, setAutoRotate] = useState(true);
@@ -133,8 +136,16 @@ export function Globe({ discoveredSlugs, onCountrySelect, discoverCountry }: Glo
         onCreated={handleCreated}
         onPointerMissed={() => closePopupRef.current?.()}
       >
-        <Suspense fallback={null}>
+        <Suspense fallback={
+          <Html center>
+            <span className="material-symbols-outlined animate-spin text-5xl text-white/60">
+              public
+            </span>
+          </Html>
+        }>
           <GlobeScene
+            countries={countries}
+            upgrading={upgrading}
             discoveredSlugs={discoveredSlugs}
             onCountrySelect={onCountrySelect}
             showLabels={showLabels}
@@ -156,6 +167,13 @@ export function Globe({ discoveredSlugs, onCountrySelect, discoverCountry }: Glo
           />
         </Suspense>
       </Canvas>
+      {loading && (
+        <div className="pointer-events-none absolute inset-0 flex items-end justify-center pb-12">
+          <span className="rounded-full bg-black/40 px-4 py-2 text-sm text-white/80 backdrop-blur-sm">
+            {t("loadingCountries")}
+          </span>
+        </div>
+      )}
       {popupData && (
         <div className="pointer-events-none absolute left-6 top-1/2 z-30 -translate-y-1/2">
           <div className="pointer-events-auto">

--- a/src/components/map/Globe.tsx
+++ b/src/components/map/Globe.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Suspense, lazy, useState, useRef, useEffect, useMemo } from "react";
+import { Suspense, lazy, useState, useRef, useEffect, useMemo, useCallback } from "react";
 import { Canvas } from "@react-three/fiber";
 import { Html } from "@react-three/drei";
 import { useLocale, useTranslations } from "next-intl";
@@ -60,13 +60,13 @@ export function Globe({ discoveredSlugs, onCountrySelect, discoverCountry }: Glo
     };
   }, [selectedSlug, locale, discoveredSlugs]);
 
-  const handleReset = () => {
+  const handleReset = useCallback(() => {
     if (cameraRef.current) {
       cameraRef.current.position.set(0, 0, 2.5);
     }
-  };
+  }, []);
 
-  const handleGeolocate = () => {
+  const handleGeolocate = useCallback(() => {
     if (!navigator.geolocation) {
       if (geoErrorTimer.current) clearTimeout(geoErrorTimer.current);
       setGeoError(t("geolocationError"));
@@ -96,9 +96,26 @@ export function Globe({ discoveredSlugs, onCountrySelect, discoverCountry }: Glo
         setGeolocating(false);
       },
     );
-  };
+  }, [t]);
 
-  const handleCreated = (state: RootState) => {
+  const globeT = useMemo(
+    () => ({
+      capital: t("capital"),
+      explore: t("explore"),
+      markExplored: t("markExplored"),
+      alreadyExplored: t("alreadyExplored"),
+    }),
+    [t],
+  );
+
+  const handleClosePopup = useCallback(() => setSelectedSlug(null), []);
+  const handleToggleLabels = useCallback(() => setShowLabels((v) => !v), []);
+  const handleToggleRotate = useCallback(() => setAutoRotate((v) => !v), []);
+  const handleToggleDaylight = useCallback(() => setIsDaylight((v) => !v), []);
+  const handleToggleMode = useCallback(() => setGlobeMode((m) => m === "realistic" ? "political" : "realistic"), []);
+  const handleToggleHoverMode = useCallback(() => setHoverMode((v) => !v), []);
+
+  const handleCreated = useCallback((state: RootState) => {
     cameraRef.current = state.camera;
     try {
       const saved = sessionStorage.getItem(SESSION_KEY);
@@ -109,7 +126,7 @@ export function Globe({ discoveredSlugs, onCountrySelect, discoverCountry }: Glo
     } catch {
       // sessionStorage unavailable — ignore
     }
-  };
+  }, []);
 
   useEffect(() => {
     return () => {
@@ -150,12 +167,7 @@ export function Globe({ discoveredSlugs, onCountrySelect, discoverCountry }: Glo
             onCountrySelect={onCountrySelect}
             showLabels={showLabels}
             locale={locale}
-            globeT={{
-              capital: t("capital"),
-              explore: t("explore"),
-              markExplored: t("markExplored"),
-              alreadyExplored: t("alreadyExplored"),
-            }}
+            globeT={globeT}
             isDaylight={isDaylight}
             autoRotate={autoRotate}
             discoverCountry={discoverCountry}
@@ -185,7 +197,7 @@ export function Globe({ discoveredSlugs, onCountrySelect, discoverCountry }: Glo
               markExploredLabel={t("markExplored")}
               alreadyExploredLabel={t("alreadyExplored")}
               onMarkExplored={discoverCountry}
-              onClose={() => setSelectedSlug(null)}
+              onClose={handleClosePopup}
             />
           </div>
         </div>
@@ -193,15 +205,15 @@ export function Globe({ discoveredSlugs, onCountrySelect, discoverCountry }: Glo
       <GlobeControls
         onReset={handleReset}
         showLabels={showLabels}
-        onToggleLabels={() => setShowLabels((v) => !v)}
+        onToggleLabels={handleToggleLabels}
         autoRotate={autoRotate}
-        onToggleRotate={() => setAutoRotate((v) => !v)}
+        onToggleRotate={handleToggleRotate}
         isDaylight={isDaylight}
-        onToggleDaylight={() => setIsDaylight((v) => !v)}
+        onToggleDaylight={handleToggleDaylight}
         globeMode={globeMode}
-        onToggleMode={() => setGlobeMode((m) => m === "realistic" ? "political" : "realistic")}
+        onToggleMode={handleToggleMode}
         hoverMode={hoverMode}
-        onToggleHoverMode={() => setHoverMode((v) => !v)}
+        onToggleHoverMode={handleToggleHoverMode}
         onGeolocate={handleGeolocate}
         geolocating={geolocating}
       />

--- a/src/components/map/GlobeScene.tsx
+++ b/src/components/map/GlobeScene.tsx
@@ -1,4 +1,4 @@
-import { useRef, type RefObject } from "react";
+import { memo, useCallback, useRef, type RefObject } from "react";
 import { OrbitControls } from "@react-three/drei";
 import { StarField } from "./StarField";
 import { GlobeSphere } from "./GlobeSphere";
@@ -26,13 +26,24 @@ type GlobeSceneProps = {
   setSelectedSlug: (slug: string | null) => void;
 };
 
-export function GlobeScene({ countries, upgrading: _upgrading, discoveredSlugs, onCountrySelect, showLabels, locale, globeT, isDaylight, autoRotate, discoverCountry, closePopupRef, globeMode, hoverMode, selectedSlug, setSelectedSlug }: GlobeSceneProps) {
+function GlobeSceneImpl({ countries, upgrading, discoveredSlugs, onCountrySelect, showLabels, locale, globeT, isDaylight, autoRotate, discoverCountry, closePopupRef, globeMode, hoverMode, selectedSlug, setSelectedSlug }: GlobeSceneProps) {
   const sphereRef = useRef<THREE.Mesh>(null);
 
-  const handleCountrySelect = (slug: string) => {
-    setSelectedSlug(slug);
-    onCountrySelect?.(slug);
-  };
+  const handleCountrySelect = useCallback(
+    (slug: string) => {
+      setSelectedSlug(slug);
+      onCountrySelect?.(slug);
+    },
+    [setSelectedSlug, onCountrySelect],
+  );
+
+  const handleCountryHover = useCallback(
+    (slug: string | null) => {
+      setSelectedSlug(slug);
+      if (slug) onCountrySelect?.(slug);
+    },
+    [setSelectedSlug, onCountrySelect],
+  );
 
   return (
     <>
@@ -42,14 +53,12 @@ export function GlobeScene({ countries, upgrading: _upgrading, discoveredSlugs, 
       <GlobeSphere ref={sphereRef} mode={globeMode} />
       <CountryMeshes
         countries={countries}
+        upgrading={upgrading}
         discoveredSlugs={discoveredSlugs}
         onCountrySelect={handleCountrySelect}
         mode={globeMode}
         hoverMode={hoverMode}
-        onCountryHover={(slug) => {
-          setSelectedSlug(slug);
-          if (slug) onCountrySelect?.(slug);
-        }}
+        onCountryHover={handleCountryHover}
       />
       <CountryLabels countries={countries} visible={showLabels} locale={locale} sphereRef={sphereRef} />
       <OrbitControls
@@ -66,3 +75,4 @@ export function GlobeScene({ countries, upgrading: _upgrading, discoveredSlugs, 
     </>
   );
 }
+export const GlobeScene = memo(GlobeSceneImpl);

--- a/src/components/map/GlobeScene.tsx
+++ b/src/components/map/GlobeScene.tsx
@@ -26,7 +26,7 @@ type GlobeSceneProps = {
   setSelectedSlug: (slug: string | null) => void;
 };
 
-export function GlobeScene({ countries, upgrading, discoveredSlugs, onCountrySelect, showLabels, locale, globeT, isDaylight, autoRotate, discoverCountry, closePopupRef, globeMode, hoverMode, selectedSlug, setSelectedSlug }: GlobeSceneProps) {
+export function GlobeScene({ countries, upgrading: _upgrading, discoveredSlugs, onCountrySelect, showLabels, locale, globeT, isDaylight, autoRotate, discoverCountry, closePopupRef, globeMode, hoverMode, selectedSlug, setSelectedSlug }: GlobeSceneProps) {
   const sphereRef = useRef<THREE.Mesh>(null);
 
   const handleCountrySelect = (slug: string) => {

--- a/src/components/map/GlobeScene.tsx
+++ b/src/components/map/GlobeScene.tsx
@@ -4,11 +4,13 @@ import { StarField } from "./StarField";
 import { GlobeSphere } from "./GlobeSphere";
 import { CountryMeshes } from "./CountryMeshes";
 import { CountryLabels } from "./CountryLabels";
-import { useGlobeData } from "@/lib/hooks/useGlobeData";
+import type { ProcessedCountry } from "@/lib/hooks/useGlobeData";
 import type * as THREE from "three";
 import type { Locale } from "@/data/types";
 
 type GlobeSceneProps = {
+  countries: ProcessedCountry[];
+  upgrading: boolean;
   discoveredSlugs: string[];
   onCountrySelect?: (slug: string) => void;
   showLabels: boolean;
@@ -24,8 +26,7 @@ type GlobeSceneProps = {
   setSelectedSlug: (slug: string | null) => void;
 };
 
-export function GlobeScene({ discoveredSlugs, onCountrySelect, showLabels, locale, globeT, isDaylight, autoRotate, discoverCountry, closePopupRef, globeMode, hoverMode, selectedSlug, setSelectedSlug }: GlobeSceneProps) {
-  const { countries } = useGlobeData();
+export function GlobeScene({ countries, upgrading, discoveredSlugs, onCountrySelect, showLabels, locale, globeT, isDaylight, autoRotate, discoverCountry, closePopupRef, globeMode, hoverMode, selectedSlug, setSelectedSlug }: GlobeSceneProps) {
   const sphereRef = useRef<THREE.Mesh>(null);
 
   const handleCountrySelect = (slug: string) => {

--- a/src/components/map/StarField.tsx
+++ b/src/components/map/StarField.tsx
@@ -1,6 +1,7 @@
+import { memo } from "react";
 import { Stars } from "@react-three/drei";
 
-export function StarField() {
+function StarFieldImpl() {
   return (
     <Stars
       radius={100}
@@ -13,3 +14,4 @@ export function StarField() {
     />
   );
 }
+export const StarField = memo(StarFieldImpl);

--- a/src/lib/hooks/useGlobeData.ts
+++ b/src/lib/hooks/useGlobeData.ts
@@ -107,7 +107,7 @@ export function useGlobeData() {
     return () => {
       cancelled = true;
     };
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+  }, []);
 
   return { countries, loading, upgrading };
 }

--- a/src/lib/hooks/useGlobeData.ts
+++ b/src/lib/hooks/useGlobeData.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useMemo } from "react";
+import { useState, useEffect } from "react";
 import { geoCentroid } from "d3-geo";
 import type { BufferGeometry } from "three";
 import type { Feature, Polygon, MultiPolygon } from "geojson";
@@ -9,6 +9,7 @@ import {
   buildCountryGeometry,
   getCountryFlagCode,
   loadWorldTopology,
+  loadLowResTopology,
 } from "@/lib/utils/geo";
 import { countriesData } from "@/data/countries";
 import type { Continent } from "@/data/types";
@@ -31,53 +32,82 @@ function featureCentroid(
   return latLngToCartesian(lat, lng, radius);
 }
 
+function processFeatures(
+  features: Feature<Polygon | MultiPolygon>[],
+): ProcessedCountry[] {
+  const result: ProcessedCountry[] = [];
+  for (const feature of features) {
+    const flagCode = getCountryFlagCode(feature);
+    if (!flagCode) continue;
+    const entry = countriesData.find((c) => c.flagCode === flagCode);
+    if (!entry) continue;
+    const geometry = buildCountryGeometry(feature, GLOBE_RADIUS);
+    if (!geometry) continue;
+    const centroid = featureCentroid(feature, GLOBE_RADIUS);
+    result.push({
+      slug: entry.slug,
+      flagCode: entry.flagCode,
+      continent: entry.continent,
+      centroid,
+      geometry,
+    });
+  }
+  return result;
+}
+
+// Module-level geometry caches — populated once, reused on every subsequent mount
+let _loCache: ProcessedCountry[] | null = null;
+let _hiCache: ProcessedCountry[] | null = null;
+
+/** @internal Test-only */
+export function _resetGlobeDataCacheForTesting(): void {
+  _loCache = null;
+  _hiCache = null;
+}
+
 export function useGlobeData() {
-  const [features, setFeatures] = useState<
-    Feature<Polygon | MultiPolygon>[] | null
-  >(null);
-  const [loading, setLoading] = useState(true);
+  const [countries, setCountries] = useState<ProcessedCountry[]>(
+    () => _hiCache ?? _loCache ?? [],
+  );
+  const [loading, setLoading] = useState(!_loCache && !_hiCache);
+  const [upgrading, setUpgrading] = useState(!!_loCache && !_hiCache);
 
   useEffect(() => {
     let cancelled = false;
-    loadWorldTopology().then((f) => {
-      if (!cancelled) {
-        setFeatures(f);
-        setLoading(false);
+
+    async function load() {
+      // Stage 1: low-res
+      if (!_loCache) {
+        const loFeatures = await loadLowResTopology();
+        if (cancelled) return;
+        _loCache = processFeatures(loFeatures);
       }
-    });
+      if (!cancelled) {
+        setCountries(_loCache!);
+        setLoading(false);
+        setUpgrading(true);
+      }
+
+      // Stage 2: hi-res
+      if (!_hiCache) {
+        const hiFeatures = await loadWorldTopology();
+        if (cancelled) return;
+        _hiCache = processFeatures(hiFeatures);
+      }
+      if (!cancelled) {
+        setCountries(_hiCache!);
+        setUpgrading(false);
+      }
+    }
+
+    if (!_hiCache) {
+      load();
+    }
+
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
-  const countries = useMemo<ProcessedCountry[]>(() => {
-    if (!features) return [];
-
-    const result: ProcessedCountry[] = [];
-
-    for (const feature of features) {
-      const flagCode = getCountryFlagCode(feature);
-      if (!flagCode) continue;
-
-      const entry = countriesData.find((c) => c.flagCode === flagCode);
-      if (!entry) continue;
-
-      const geometry = buildCountryGeometry(feature, GLOBE_RADIUS);
-      if (!geometry) continue;
-
-      const centroid = featureCentroid(feature, GLOBE_RADIUS);
-
-      result.push({
-        slug: entry.slug,
-        flagCode: entry.flagCode,
-        continent: entry.continent,
-        centroid,
-        geometry,
-      });
-    }
-
-    return result;
-  }, [features]);
-
-  return { countries, loading };
+  return { countries, loading, upgrading };
 }

--- a/src/lib/utils/geo.ts
+++ b/src/lib/utils/geo.ts
@@ -643,9 +643,13 @@ export function getCountryFlagCode(
  *     world-10m  ~1000 KB   10 km tolerance  too large for browser use
  * ────────────────────────────────────────────────────────────────────────────
  */
+let _topologyCache: Feature<Polygon | MultiPolygon>[] | null = null;
+
 export async function loadWorldTopology(): Promise<
   Feature<Polygon | MultiPolygon>[]
 > {
+  if (_topologyCache) return _topologyCache;
+
   const response = await fetch("/geo/world-50m.json");
   const topology = (await response.json()) as Topology<{
     countries: GeometryCollection;
@@ -656,5 +660,6 @@ export async function loadWorldTopology(): Promise<
     topology.objects.countries,
   ) as unknown as { features: Feature<Polygon | MultiPolygon>[] };
 
-  return features;
+  _topologyCache = features;
+  return _topologyCache;
 }

--- a/src/lib/utils/geo.ts
+++ b/src/lib/utils/geo.ts
@@ -645,6 +645,11 @@ export function getCountryFlagCode(
  */
 let _topologyCache: Feature<Polygon | MultiPolygon>[] | null = null;
 
+/** @internal Test-only — resets the module-level topology cache */
+export function _resetTopologyCacheForTesting(): void {
+  _topologyCache = null;
+}
+
 export async function loadWorldTopology(): Promise<
   Feature<Polygon | MultiPolygon>[]
 > {

--- a/src/lib/utils/geo.ts
+++ b/src/lib/utils/geo.ts
@@ -668,3 +668,40 @@ export async function loadWorldTopology(): Promise<
   _topologyCache = features;
   return _topologyCache;
 }
+
+// ---------------------------------------------------------------------------
+// Load low-resolution world topology
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetch the Natural Earth world topology at low resolution for fast initial
+ * rendering. Used as stage 1 in the progressive LOD loading strategy.
+ *
+ * Resolution: world-110m.json (~100 KB, 110 km coastline tolerance)
+ * This is the fast-loading counterpart to loadWorldTopology() (world-50m.json).
+ */
+let _lowResTopologyCache: Feature<Polygon | MultiPolygon>[] | null = null;
+
+/** @internal Test-only — resets the module-level low-res topology cache */
+export function _resetLowResTopologyCacheForTesting(): void {
+  _lowResTopologyCache = null;
+}
+
+export async function loadLowResTopology(): Promise<
+  Feature<Polygon | MultiPolygon>[]
+> {
+  if (_lowResTopologyCache) return _lowResTopologyCache;
+
+  const response = await fetch("/geo/world-110m.json");
+  const topology = (await response.json()) as Topology<{
+    countries: GeometryCollection;
+  }>;
+
+  const { features } = topojson.feature(
+    topology,
+    topology.objects.countries,
+  ) as unknown as { features: Feature<Polygon | MultiPolygon>[] };
+
+  _lowResTopologyCache = features;
+  return _lowResTopologyCache;
+}


### PR DESCRIPTION
Closes #75

## Changes

### Task 1: Module-level topology caches
- `geo.ts`: Added `_topologyCache` and `_lowResTopologyCache` module-level variables. `loadWorldTopology()` returns cached result on subsequent calls. New `loadLowResTopology()` loads `world-110m.json` with its own cache.
- Tests: identity reference and call-count assertions, isolated with `afterEach` reset helpers.

### Task 2: LOD progressive loading
- `useGlobeData.ts`: Fully rewritten with two-stage load. Lo-res (110m) loads first for fast initial display; hi-res (50m) upgrades in background. Module-level `_loCache`/`_hiCache` eliminate re-triangulation on remount.
- Returns `{ countries, loading, upgrading }` states for progressive UX.
- Tests: 5 cases covering state transitions and warm-cache path.

### Task 3: Loading UX
- `Globe.tsx`: Lifted `useGlobeData()` here to expose `loading` for HTML overlay. Replaced `<Suspense fallback={null}>` with animated `Html center` spinner. Added bottom-center pill overlay while `loading === true`.
- `GlobeScene.tsx`: Receives `countries` and `upgrading` as props (fetch no longer duplicated).
- i18n: `loadingCountries` key added to both `en.json` and `es.json`.

### Task 4: React.memo + useCallback
- `Globe.tsx`: All handlers stabilized with `useCallback`; `globeT` object wrapped in `useMemo` to prevent defeating GlobeScene memo.
- `GlobeScene.tsx`: Wrapped with `memo`; internal `handleCountrySelect` and `handleCountryHover` wrapped with `useCallback`.
- `CountryMeshes.tsx`, `CountryLabels.tsx`, `StarField.tsx`: All wrapped with `memo`.

## Performance Impact
- Initial load: black screen eliminated — lo-res countries appear in ~1s
- Navigation: full re-init eliminated — all geometry served from module-level cache
- Render: memo boundaries prevent cascade re-renders on state changes

## Testing
- 151/151 tests passing
- Build clean
- Lint: matches `main` baseline (14 pre-existing errors, no new errors)