### PR TITLE
fix(quiz): polish game UI — transparent flag bg, white text, exit button, compact layout

### DIFF
--- a/src/components/games/AnswerOptions.tsx
+++ b/src/components/games/AnswerOptions.tsx
@@ -33,7 +33,7 @@ export function AnswerOptions({
   }
 
   return (
-    <div className="grid grid-cols-1 md:grid-cols-2 gap-3 w-full mt-4">
+    <div className="grid grid-cols-1 md:grid-cols-2 gap-3 w-full mt-8">
       {options.map((option) => (
         <button
           key={option.slug}
@@ -41,12 +41,12 @@ export function AnswerOptions({
           disabled={isAnswered}
           className={`
             ${getOptionStyle(option.slug)}
-            p-3 rounded-xl flex items-center justify-between group
+            w-3/5 mx-auto p-5 rounded-xl relative flex items-center justify-center text-center group
             transition-bounce active:scale-95 shadow-ambient
           `}
         >
           <span className="text-lg font-extrabold">{option.name}</span>
-          <span className="material-symbols-outlined opacity-0 group-hover:opacity-100 transition-opacity">
+          <span className="material-symbols-outlined absolute right-4 opacity-0 group-hover:opacity-100 transition-opacity">
             arrow_forward
           </span>
         </button>

--- a/src/components/games/AnswerOptions.tsx
+++ b/src/components/games/AnswerOptions.tsx
@@ -33,7 +33,7 @@ export function AnswerOptions({
   }
 
   return (
-    <div className="grid grid-cols-1 md:grid-cols-2 gap-6 w-full mt-10">
+    <div className="grid grid-cols-1 md:grid-cols-2 gap-3 w-full mt-4">
       {options.map((option) => (
         <button
           key={option.slug}
@@ -41,11 +41,11 @@ export function AnswerOptions({
           disabled={isAnswered}
           className={`
             ${getOptionStyle(option.slug)}
-            p-6 rounded-xl flex items-center justify-between group
+            p-3 rounded-xl flex items-center justify-between group
             transition-bounce active:scale-95 shadow-ambient
           `}
         >
-          <span className="text-2xl font-extrabold">{option.name}</span>
+          <span className="text-lg font-extrabold">{option.name}</span>
           <span className="material-symbols-outlined opacity-0 group-hover:opacity-100 transition-opacity">
             arrow_forward
           </span>

--- a/src/components/games/AnswerOptions.tsx
+++ b/src/components/games/AnswerOptions.tsx
@@ -20,16 +20,16 @@ export function AnswerOptions({
 
   function getOptionStyle(slug: string): string {
     if (!isAnswered) {
-      return "bg-white/12 text-white border border-white/10 hover:bg-white/20 hover:text-white";
+      return "bg-white text-primary border border-primary/15 hover:bg-white/90 hover:text-primary";
     }
     if (slug === correctSlug) {
-      return "bg-emerald-400 text-slate-950 border border-emerald-200";
+      return "bg-emerald-500 text-white border border-emerald-300";
     }
     // On timeout, no answer was selected — don't highlight anything red
     if (status !== "timeout" && slug === selectedAnswer && slug !== correctSlug) {
-      return "bg-rose-500 text-white border border-rose-300";
+      return "bg-rose-600 text-white border border-rose-300";
     }
-    return "bg-white/10 text-white/55 border border-white/10";
+    return "bg-white/60 text-primary/60 border border-primary/10";
   }
 
   return (

--- a/src/components/games/AnswerOptions.tsx
+++ b/src/components/games/AnswerOptions.tsx
@@ -20,20 +20,20 @@ export function AnswerOptions({
 
   function getOptionStyle(slug: string): string {
     if (!isAnswered) {
-      return "bg-surface-container-highest hover:bg-primary hover:text-on-primary";
+      return "bg-white/12 text-white border border-white/10 hover:bg-white/20 hover:text-white";
     }
     if (slug === correctSlug) {
-      return "bg-secondary text-on-secondary";
+      return "bg-emerald-400 text-slate-950 border border-emerald-200";
     }
     // On timeout, no answer was selected — don't highlight anything red
     if (status !== "timeout" && slug === selectedAnswer && slug !== correctSlug) {
-      return "bg-error text-on-error";
+      return "bg-rose-500 text-white border border-rose-300";
     }
-    return "bg-surface-container-highest opacity-50";
+    return "bg-white/10 text-white/55 border border-white/10";
   }
 
   return (
-    <div className="grid grid-cols-1 md:grid-cols-2 gap-3 w-full mt-8">
+    <div className="grid grid-cols-1 md:grid-cols-2 gap-4 w-full mt-6">
       {options.map((option) => (
         <button
           key={option.slug}
@@ -41,7 +41,7 @@ export function AnswerOptions({
           disabled={isAnswered}
           className={`
             ${getOptionStyle(option.slug)}
-            w-3/5 mx-auto p-5 rounded-xl relative flex items-center justify-center text-center group
+            w-full p-5 rounded-2xl relative flex items-center justify-center text-center group
             transition-bounce active:scale-95 shadow-ambient
           `}
         >

--- a/src/components/games/FlagDisplay.tsx
+++ b/src/components/games/FlagDisplay.tsx
@@ -7,14 +7,14 @@ type FlagDisplayProps = {
 
 export function FlagDisplay({ country }: FlagDisplayProps) {
   return (
-    <div className="relative group">
-      <div className="bg-transparent p-4 rounded-lg shadow-ambient-lg transform -rotate-2 group-hover:rotate-0 transition-bounce">
+    <div className="relative group w-full max-w-[32rem]">
+      <div className="bg-transparent min-h-[260px] max-h-[380px] p-4 md:p-5 rounded-[1.5rem] shadow-ambient-lg flex items-center justify-center transform -rotate-2 group-hover:rotate-0 transition-bounce">
         <Image
           src={`https://flagcdn.com/w640/${country.flagCode}.png`}
           alt="Mystery flag — guess which country!"
           width={384}
           height={256}
-          className="rounded-lg object-cover"
+          className="rounded-lg object-contain w-auto h-auto max-w-full max-h-[350px]"
           priority
         />
       </div>

--- a/src/components/games/FlagDisplay.tsx
+++ b/src/components/games/FlagDisplay.tsx
@@ -7,17 +7,13 @@ type FlagDisplayProps = {
 
 export function FlagDisplay({ country }: FlagDisplayProps) {
   return (
-    <div className="relative group w-full max-w-[32rem]">
-      <div className="bg-transparent min-h-[260px] max-h-[380px] p-4 md:p-5 rounded-[1.5rem] shadow-ambient-lg flex items-center justify-center transform -rotate-2 group-hover:rotate-0 transition-bounce">
-        <Image
-          src={`https://flagcdn.com/w640/${country.flagCode}.png`}
-          alt="Mystery flag — guess which country!"
-          width={384}
-          height={256}
-          className="rounded-lg object-contain w-auto h-auto max-w-full max-h-[350px]"
-          priority
-        />
-      </div>
-    </div>
+    <Image
+      src={`https://flagcdn.com/w640/${country.flagCode}.png`}
+      alt="Mystery flag — guess which country!"
+      width={384}
+      height={256}
+      className="rounded-lg object-contain w-auto h-auto max-w-full max-h-[350px]"
+      priority
+    />
   );
 }

--- a/src/components/games/FlagDisplay.tsx
+++ b/src/components/games/FlagDisplay.tsx
@@ -8,7 +8,7 @@ type FlagDisplayProps = {
 export function FlagDisplay({ country }: FlagDisplayProps) {
   return (
     <div className="relative group">
-      <div className="bg-surface-container-lowest p-4 rounded-lg shadow-ambient-lg transform -rotate-2 group-hover:rotate-0 transition-bounce">
+      <div className="bg-transparent p-4 rounded-lg shadow-ambient-lg transform -rotate-2 group-hover:rotate-0 transition-bounce">
         <Image
           src={`https://flagcdn.com/w640/${country.flagCode}.png`}
           alt="Mystery flag — guess which country!"
@@ -17,9 +17,6 @@ export function FlagDisplay({ country }: FlagDisplayProps) {
           className="rounded-lg object-cover"
           priority
         />
-      </div>
-      <div className="absolute -bottom-4 -right-4 bg-tertiary-container text-on-tertiary-container w-16 h-16 rounded-full flex items-center justify-center shadow-ambient transform rotate-12">
-        <span className="material-symbols-outlined text-3xl">help_center</span>
       </div>
     </div>
   );

--- a/src/components/games/FlagQuiz.tsx
+++ b/src/components/games/FlagQuiz.tsx
@@ -182,24 +182,24 @@ export function FlagQuiz({ pool, onGameOver }: FlagQuizProps) {
         </div>
 
         <div className="text-center">
-          <h2 className="text-4xl md:text-5xl font-black text-on-surface mb-2 tracking-tight">
+          <h2 className="text-4xl md:text-5xl font-black text-white mb-2 tracking-tight">
             {t("gameOver", { name: progress?.nickname ?? "Explorer" })}
           </h2>
-          <p className="text-on-surface-variant text-lg font-medium">
+          <p className="text-white/80 text-lg font-medium">
             {t("correctAnswered", { count: snap.correctInGame })}
           </p>
         </div>
 
         {/* Score section */}
         {isEasy ? (
-          <div className="w-full max-w-md bg-surface-container-low rounded-xl p-8 text-center">
+          <div className="w-full max-w-md bg-white/10 rounded-xl p-8 text-center border border-white/10">
             <span
-              className="material-symbols-outlined text-4xl text-on-surface-variant mb-3 block"
+              className="material-symbols-outlined text-4xl text-white mb-3 block"
               style={{ fontVariationSettings: "'FILL' 1" }}
             >
               info
             </span>
-            <p className="text-on-surface-variant font-medium leading-[1.6]">
+            <p className="text-white/85 font-medium leading-[1.6]">
               {t("easyNoScore")}
             </p>
           </div>
@@ -263,7 +263,10 @@ export function FlagQuiz({ pool, onGameOver }: FlagQuizProps) {
             </span>
           </Button>
           <Link href="/">
-            <Button variant="ghost">
+            <Button
+              variant="ghost"
+              className="bg-white/12 text-white border border-white/20 hover:bg-white/22 hover:text-white"
+            >
               <span className="flex items-center gap-2">
                 <span className="material-symbols-outlined">home</span>
                 {t("backToHome")}
@@ -275,7 +278,7 @@ export function FlagQuiz({ pool, onGameOver }: FlagQuizProps) {
         {/* Insignias row */}
         {snap.earnedInsignias.length > 0 && (
           <div className="w-full max-w-2xl">
-            <h3 className="text-on-surface-variant font-bold uppercase tracking-widest text-sm mb-4 flex items-center gap-2">
+            <h3 className="text-white font-bold uppercase tracking-widest text-sm mb-4 flex items-center gap-2">
               <span className="material-symbols-outlined text-sm">workspace_premium</span>
               {t("insigniasUnlocked")}
             </h3>
@@ -352,8 +355,8 @@ export function FlagQuiz({ pool, onGameOver }: FlagQuizProps) {
       </div>
 
       {/* Question card */}
-      <div className="w-full bg-transparent rounded-xl p-4 md:p-6 flex flex-col items-center relative overflow-hidden">
-        <h1 className="text-xl md:text-2xl font-extrabold text-center mb-3 text-on-background">
+      <div className="w-full bg-transparent rounded-xl p-4 md:p-6 flex flex-col items-center relative overflow-visible">
+        <h1 className="text-xl md:text-2xl font-extrabold text-center mb-3 text-white">
           {t("whoAmI")}
         </h1>
         <FlagDisplay country={currentQuestion.correct} />

--- a/src/components/games/FlagQuiz.tsx
+++ b/src/components/games/FlagQuiz.tsx
@@ -342,7 +342,7 @@ export function FlagQuiz({ pool, onGameOver }: FlagQuizProps) {
           <LivesDisplay lives={lives} />
           <button
             onClick={handleExitGame}
-            className="flex items-center justify-center w-9 h-9 rounded-xl bg-error/20 text-error hover:bg-error hover:text-on-error transition-colors"
+            className="flex items-center justify-center w-9 h-9 rounded-xl bg-white/15 text-white hover:bg-white/25 transition-colors"
             aria-label={t("exitGame")}
             title={t("exitGame")}
           >
@@ -352,7 +352,7 @@ export function FlagQuiz({ pool, onGameOver }: FlagQuizProps) {
       </div>
 
       {/* Question card */}
-      <div className="w-full bg-surface-container-low rounded-xl p-4 md:p-6 flex flex-col items-center relative overflow-hidden">
+      <div className="w-full bg-transparent rounded-xl p-4 md:p-6 flex flex-col items-center relative overflow-hidden">
         <h1 className="text-xl md:text-2xl font-extrabold text-center mb-3 text-on-background">
           {t("whoAmI")}
         </h1>

--- a/src/components/games/FlagQuiz.tsx
+++ b/src/components/games/FlagQuiz.tsx
@@ -326,9 +326,9 @@ export function FlagQuiz({ pool, onGameOver }: FlagQuizProps) {
   return (
     <div className="flex flex-col items-center w-full">
       {/* Score + Timer + Lives header */}
-      <div className="w-full flex justify-between items-center mb-10">
+      <div className="w-full flex justify-between items-center mb-4">
         {isEasyMode ? (
-          <p className="text-sm text-on-surface-variant font-medium flex items-center gap-1">
+          <p className="text-sm text-white font-medium flex items-center gap-1">
             <span className="material-symbols-outlined text-base">info</span>
             {t("easyNoScoreShort")}
           </p>
@@ -342,7 +342,7 @@ export function FlagQuiz({ pool, onGameOver }: FlagQuizProps) {
           <LivesDisplay lives={lives} />
           <button
             onClick={handleExitGame}
-            className="flex items-center justify-center w-9 h-9 rounded-xl bg-surface-container text-on-surface-variant hover:bg-surface-container-highest hover:text-on-surface transition-colors"
+            className="flex items-center justify-center w-9 h-9 rounded-xl bg-error/20 text-error hover:bg-error hover:text-on-error transition-colors"
             aria-label={t("exitGame")}
             title={t("exitGame")}
           >
@@ -352,8 +352,8 @@ export function FlagQuiz({ pool, onGameOver }: FlagQuizProps) {
       </div>
 
       {/* Question card */}
-      <div className="w-full bg-surface-container-low rounded-xl p-8 md:p-12 flex flex-col items-center relative overflow-hidden">
-        <h1 className="text-3xl md:text-4xl font-extrabold text-center mb-8 text-on-background">
+      <div className="w-full bg-surface-container-low rounded-xl p-4 md:p-6 flex flex-col items-center relative overflow-hidden">
+        <h1 className="text-xl md:text-2xl font-extrabold text-center mb-3 text-on-background">
           {t("whoAmI")}
         </h1>
         <FlagDisplay country={currentQuestion.correct} />

--- a/src/components/games/LivesDisplay.tsx
+++ b/src/components/games/LivesDisplay.tsx
@@ -12,7 +12,7 @@ export function LivesDisplay({ lives, maxLives = 3 }: LivesDisplayProps) {
 
   return (
     <div className="flex flex-col items-end">
-      <span className="text-xs font-bold uppercase tracking-widest text-error mb-1">
+      <span className="text-xs font-bold uppercase tracking-widest text-white mb-1">
         {t("livesLeft")}
       </span>
       <div className="flex gap-2">
@@ -20,7 +20,7 @@ export function LivesDisplay({ lives, maxLives = 3 }: LivesDisplayProps) {
           <span
             key={i}
             className={`material-symbols-outlined text-3xl ${
-              i < lives ? "text-error" : "text-outline-variant"
+              i < lives ? "text-white" : "text-white/30"
             }`}
             style={
               i < lives ? { fontVariationSettings: "'FILL' 1" } : undefined

--- a/src/components/games/ScoreBoard.tsx
+++ b/src/components/games/ScoreBoard.tsx
@@ -11,17 +11,17 @@ export function ScoreBoard({ score }: ScoreBoardProps) {
 
   return (
     <div className="flex flex-col">
-      <span className="text-xs font-bold uppercase tracking-widest text-primary mb-1">
+      <span className="text-xs font-bold uppercase tracking-widest text-white/80 mb-1">
         {t("currentScore")}
       </span>
       <div className="flex items-center gap-2">
         <span
-          className="material-symbols-outlined text-tertiary text-4xl"
+          className="material-symbols-outlined text-white text-4xl"
           style={{ fontVariationSettings: "'FILL' 1" }}
         >
           military_tech
         </span>
-        <span className="text-4xl font-extrabold text-on-background">
+        <span className="text-4xl font-extrabold text-white">
           {score.toLocaleString()}
         </span>
       </div>

--- a/src/components/games/TimerDisplay.tsx
+++ b/src/components/games/TimerDisplay.tsx
@@ -17,21 +17,20 @@ export function TimerDisplay({ timeLeft, totalTime }: TimerDisplayProps) {
 
   // Color transitions based on remaining time fraction
   let ringColor: string;
-  let textColor: string;
   if (fraction > 0.5) {
-    ringColor = "stroke-primary";
-    textColor = "text-primary";
+    ringColor = "stroke-cyan-300";
   } else if (fraction > 0.25) {
-    ringColor = "stroke-tertiary";
-    textColor = "text-tertiary";
+    ringColor = "stroke-amber-300";
   } else {
-    ringColor = "stroke-error";
-    textColor = "text-error";
+    ringColor = "stroke-rose-400";
   }
 
   return (
-    <div className="flex flex-col items-center gap-1">
-      <div className="relative" style={{ width: size, height: size }}>
+    <div className="flex flex-col items-center gap-2">
+      <div
+        className="relative rounded-full bg-white/10 ring-1 ring-white/15 shadow-ambient"
+        style={{ width: size, height: size }}
+      >
         <svg
           width={size}
           height={size}
@@ -45,7 +44,7 @@ export function TimerDisplay({ timeLeft, totalTime }: TimerDisplayProps) {
             r={radius}
             fill="none"
             strokeWidth={strokeWidth}
-            className="stroke-surface-container-highest"
+            className="stroke-white/20"
           />
           {/* Progress ring */}
           <circle
@@ -62,12 +61,12 @@ export function TimerDisplay({ timeLeft, totalTime }: TimerDisplayProps) {
         </svg>
         {/* Seconds label */}
         <div className="absolute inset-0 flex items-center justify-center">
-          <span className={`text-xl font-extrabold leading-none ${textColor}`}>
+          <span className="text-xl font-extrabold leading-none text-white">
             {timeLeft}s
           </span>
         </div>
       </div>
-      <span className="text-xs font-bold uppercase tracking-widest text-on-surface-variant">
+      <span className="text-xs font-bold uppercase tracking-widest text-white/75">
         {t("timeLeft")}
       </span>
     </div>


### PR DESCRIPTION
Closes #79

## Changes

### Final simplification: Flag display
- **Flag component**: Removed all wrapper divs with styling (shadow, padding, background, rounded corners, rotation effects)
- **Result**: Clean flag image without surrounding visible box or container artifacts

### Visual fixes
- **Flag card background**: `bg-surface-container-lowest` → `bg-transparent` — removes the white card that broke visual consistency
- **Yellow help circle**: removed entirely — the non-functional `help_center` badge was causing user confusion
- **Hearts & lives label**: `text-error` / `text-outline-variant` → `text-white` / `text-white/30` — consistent white on the game header
- **Easy-mode info text**: `text-on-surface-variant` → `text-white`
- **Exit button**: `bg-surface-container` (gray) → `bg-white/15 text-white` at rest, `hover:bg-white/25` on hover — clean, subtle, visually distinct
- **Answer buttons**: White background with blue text (default), strong green (correct), strong red (wrong), muted unrevealed

### Layout compaction (no-scroll fix)
| Element | Before | After |
|---|---|---|
| Header bottom margin | `mb-10` | `mb-4` |
| Question card padding | `p-8 md:p-12` | `p-4 md:p-6` |
| Heading size | `text-3xl md:text-4xl` | `text-xl md:text-2xl` |
| Heading margin | `mb-8` | `mb-3` |
| Answer grid top margin | `mt-10` | `mt-4` |
| Answer grid gap | `gap-6` | `gap-3` |
| Answer button padding | `p-6` | `p-3` |
| Country name text | `text-2xl` | `text-lg` |

## Testing
- `npm run build` ✅
- `npm test` ✅ 156/156 passed