### PR TITLE
fix(map): remove satellite, label, and reset buttons from globe controls

### DIFF
--- a/src/components/map/Globe.tsx
+++ b/src/components/map/Globe.tsx
@@ -60,12 +60,6 @@ export function Globe({ discoveredSlugs, onCountrySelect, discoverCountry }: Glo
     };
   }, [selectedSlug, locale, discoveredSlugs]);
 
-  const handleReset = useCallback(() => {
-    if (cameraRef.current) {
-      cameraRef.current.position.set(0, 0, 2.5);
-    }
-  }, []);
-
   const handleGeolocate = useCallback(() => {
     if (!navigator.geolocation) {
       if (geoErrorTimer.current) clearTimeout(geoErrorTimer.current);
@@ -109,10 +103,8 @@ export function Globe({ discoveredSlugs, onCountrySelect, discoverCountry }: Glo
   );
 
   const handleClosePopup = useCallback(() => setSelectedSlug(null), []);
-  const handleToggleLabels = useCallback(() => setShowLabels((v) => !v), []);
   const handleToggleRotate = useCallback(() => setAutoRotate((v) => !v), []);
   const handleToggleDaylight = useCallback(() => setIsDaylight((v) => !v), []);
-  const handleToggleMode = useCallback(() => setGlobeMode((m) => m === "realistic" ? "political" : "realistic"), []);
   const handleToggleHoverMode = useCallback(() => setHoverMode((v) => !v), []);
 
   const handleCreated = useCallback((state: RootState) => {
@@ -202,15 +194,10 @@ export function Globe({ discoveredSlugs, onCountrySelect, discoverCountry }: Glo
         </div>
       )}
       <GlobeControls
-        onReset={handleReset}
-        showLabels={showLabels}
-        onToggleLabels={handleToggleLabels}
         autoRotate={autoRotate}
         onToggleRotate={handleToggleRotate}
         isDaylight={isDaylight}
         onToggleDaylight={handleToggleDaylight}
-        globeMode={globeMode}
-        onToggleMode={handleToggleMode}
         hoverMode={hoverMode}
         onToggleHoverMode={handleToggleHoverMode}
         onGeolocate={handleGeolocate}

--- a/src/components/map/GlobeControls.tsx
+++ b/src/components/map/GlobeControls.tsx
@@ -1,15 +1,10 @@
 import { useTranslations } from "next-intl";
 
 type GlobeControlsProps = {
-  onReset: () => void;
-  showLabels: boolean;
-  onToggleLabels: () => void;
   autoRotate: boolean;
   onToggleRotate: () => void;
   isDaylight: boolean;
   onToggleDaylight: () => void;
-  globeMode: "realistic" | "political";
-  onToggleMode: () => void;
   hoverMode: boolean;
   onToggleHoverMode: () => void;
   onGeolocate: () => void;
@@ -17,15 +12,10 @@ type GlobeControlsProps = {
 };
 
 export function GlobeControls({
-  onReset,
-  showLabels,
-  onToggleLabels,
   autoRotate,
   onToggleRotate,
   isDaylight,
   onToggleDaylight,
-  globeMode,
-  onToggleMode,
   hoverMode,
   onToggleHoverMode,
   onGeolocate,
@@ -37,15 +27,6 @@ export function GlobeControls({
 
   return (
     <div className="absolute bottom-8 right-8 z-10 flex flex-col gap-3">
-      <button
-        onClick={onToggleMode}
-        className={btnBase}
-        aria-label={globeMode === "realistic" ? t("politicalMode") : t("realisticMode")}
-      >
-        <span className="material-symbols-outlined">
-          {globeMode === "realistic" ? "map" : "satellite_alt"}
-        </span>
-      </button>
       <button
         onClick={onToggleDaylight}
         className={btnBase}
@@ -72,22 +53,6 @@ export function GlobeControls({
         <span className="material-symbols-outlined">
           {hoverMode ? "mouse" : "touch_app"}
         </span>
-      </button>
-      <button
-        onClick={onToggleLabels}
-        className={btnBase}
-        aria-label={showLabels ? t("hideLabels") : t("showLabels")}
-      >
-        <span className="material-symbols-outlined">
-          {showLabels ? "label_off" : "label"}
-        </span>
-      </button>
-      <button
-        onClick={onReset}
-        className={btnBase}
-        aria-label={t("reset")}
-      >
-        <span className="material-symbols-outlined">refresh</span>
       </button>
       <button
         onClick={onGeolocate}


### PR DESCRIPTION
Closes #81

## Changes
- Removed globe mode toggle button (`satellite_alt`/`map` icon)
- Removed country labels toggle button (`label`/`label_off` icon)
- Removed reset button (`refresh` icon)
- Cleaned up 5 props from `GlobeControlsProps` (`onReset`, `showLabels`, `onToggleLabels`, `globeMode`, `onToggleMode`)
- Removed 3 dead `useCallback` handlers from `Globe.tsx` (`handleReset`, `handleToggleLabels`, `handleToggleMode`)
- `showLabels` and `globeMode` state retained — still consumed by `GlobeScene` for rendering

## Testing
- `npm run build` ✅
- `npm test` ✅ 155/156 passed (1 pre-existing failure in `useGlobeData` unrelated to this change)