### PR TITLE
fix(topnav): improve mobile header visibility by hiding quick map/game icons

### DIFF
--- a/src/__tests__/components/TopNav.test.tsx
+++ b/src/__tests__/components/TopNav.test.tsx
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, within, cleanup } from "@testing-library/react";
+import type { ComponentPropsWithoutRef } from "react";
+import { TopNav } from "@/components/layout/TopNav";
+
+const mockUseAuth = vi.fn();
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+vi.mock("@/i18n/navigation", () => ({
+  usePathname: () => "/",
+  Link: ({ href, className, children, ...props }: ComponentPropsWithoutRef<"a"> & { href: string }) => (
+    <a href={href} className={className} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("@/lib/providers/AuthProvider", () => ({
+  useAuth: () => mockUseAuth(),
+}));
+
+vi.mock("@/components/auth/AuthModal", () => ({
+  AuthModal: () => null,
+}));
+
+vi.mock("@/components/auth/ProfileDialog", () => ({
+  ProfileDialog: () => null,
+}));
+
+vi.mock("@/components/layout/LanguageToggle", () => ({
+  LanguageToggle: () => <button type="button">Language</button>,
+}));
+
+vi.mock("@/components/ui/SearchInput", () => ({
+  SearchInput: () => <input aria-label="search" />,
+}));
+
+describe("TopNav", () => {
+  beforeEach(() => {
+    mockUseAuth.mockReset();
+    cleanup();
+  });
+
+  it("keeps language and profile controls while quick icon links are mobile-hidden", () => {
+    mockUseAuth.mockReturnValue({
+      isAnonymous: false,
+      nickname: "Explorer Kid",
+      avatarUrl: "https://example.com/avatar.png",
+    });
+
+    render(<TopNav />);
+
+    expect(screen.getByRole("button", { name: "Language" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Open profile" })).toBeInTheDocument();
+
+    const quickLinks = screen.getByLabelText("Quick links");
+    expect(quickLinks).toHaveClass("hidden");
+    expect(quickLinks).toHaveClass("md:flex");
+
+    expect(within(quickLinks).getByRole("link", { name: "map" })).toBeInTheDocument();
+    expect(within(quickLinks).getByRole("link", { name: "games" })).toBeInTheDocument();
+  });
+
+  it("keeps language and sign-in controls visible for anonymous users", () => {
+    mockUseAuth.mockReturnValue({
+      isAnonymous: true,
+      nickname: "Explorer",
+      avatarUrl: "https://example.com/avatar.png",
+    });
+
+    render(<TopNav />);
+
+    expect(screen.getByRole("button", { name: "Language" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "signIn" })).toBeInTheDocument();
+
+    const quickLinks = screen.getByLabelText("Quick links");
+    expect(quickLinks).toHaveClass("hidden");
+    expect(quickLinks).toHaveClass("md:flex");
+  });
+});

--- a/src/components/layout/TopNav.tsx
+++ b/src/components/layout/TopNav.tsx
@@ -41,10 +41,10 @@ export function TopNav({ searchQuery, onSearchChange, transparent = false }: Top
             : "glass sticky top-0 z-40"
         }
       >
-        <div className="flex justify-between items-center w-full px-8 py-4 max-w-screen-2xl mx-auto">
+        <div className="flex justify-between items-center w-full px-4 sm:px-8 py-3 sm:py-4 max-w-screen-2xl mx-auto">
           <Link
             href="/"
-            className={`text-2xl font-extrabold tracking-tight ${
+            className={`text-xl sm:text-2xl font-extrabold tracking-tight ${
               transparent ? "text-white" : "text-primary"
             }`}
           >
@@ -80,7 +80,7 @@ export function TopNav({ searchQuery, onSearchChange, transparent = false }: Top
             })}
           </nav>
 
-          <div className="flex items-center gap-4">
+          <div className="flex items-center gap-2 sm:gap-4">
             {onSearchChange && (
               <div className="hidden sm:block">
                 <SearchInput
@@ -91,15 +91,17 @@ export function TopNav({ searchQuery, onSearchChange, transparent = false }: Top
               </div>
             )}
             <LanguageToggle />
-            <div className="flex gap-2">
+            <div className="hidden md:flex gap-2" aria-label="Quick links">
               <Link
                 href="/map"
+                aria-label={t("map")}
                 className="material-symbols-outlined text-primary p-2 bg-surface-container-low rounded-full hover:scale-105 transition-bounce"
               >
                 public
               </Link>
               <Link
                 href="/games/guess-the-flag"
+                aria-label={t("games")}
                 className="material-symbols-outlined text-primary p-2 bg-surface-container-low rounded-full hover:scale-105 transition-bounce"
               >
                 sports_esports
@@ -117,7 +119,7 @@ export function TopNav({ searchQuery, onSearchChange, transparent = false }: Top
             ) : (
               <button
                 onClick={() => setIsProfileOpen(true)}
-                className="flex items-center gap-2 px-3 py-1.5 bg-surface-container-low rounded-full hover:bg-surface-container transition-bounce"
+                className="flex items-center gap-2 px-2.5 sm:px-3 py-1.5 bg-surface-container-low rounded-full hover:bg-surface-container transition-bounce"
                 aria-label="Open profile"
               >
                 {/* eslint-disable-next-line @next/next/no-img-element */}


### PR DESCRIPTION
Closes #83

## Changes
- Hide top-right map and games quick-link icon buttons on mobile (`hidden md:flex`)
- Keep language toggle and profile/sign-in controls visible in mobile header
- Improve small-screen spacing in TopNav for better control visibility
- Add aria-labels to icon-only quick links (`map`, `games`)
- Add regression tests for TopNav responsive control behavior

## Testing
- `npm test -- src/__tests__/components/TopNav.test.tsx` ✅
- `npm test` ⚠️ 157/158 passed (1 pre-existing failure in `useGlobeData` unrelated to this change)
