### PR TITLE
fix: language selector flags + rankings refresh race condition

### DIFF
--- a/src/components/layout/LanguageToggle.tsx
+++ b/src/components/layout/LanguageToggle.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Image from "next/image";
 import { useLocale } from "next-intl";
 import { useRouter, usePathname } from "@/i18n/navigation";
 
@@ -13,13 +14,26 @@ export function LanguageToggle() {
     router.replace(pathname, { locale: newLocale });
   }
 
+  // When viewing in English → offer to switch to Spanish (show ES flag)
+  // When viewing in Spanish → offer to switch to English (show GB flag)
+  const targetFlag = locale === "en" ? "es" : "gb";
+  const targetLabel = locale === "en" ? "ES" : "EN";
+  const ariaLabel = locale === "en" ? "Cambiar a español" : "Switch to English";
+
   return (
     <button
       onClick={switchLocale}
       className="flex items-center gap-1.5 px-3 py-1.5 bg-surface-container-high rounded-full text-sm font-bold text-on-surface hover:bg-surface-container-highest transition-bounce"
-      aria-label={locale === "en" ? "Cambiar a español" : "Switch to English"}
+      aria-label={ariaLabel}
     >
-      {locale === "en" ? "🇪🇸 ES" : "🇬🇧 EN"}
+      <Image
+        src={`https://flagcdn.com/w20/${targetFlag}.png`}
+        alt={targetLabel}
+        width={20}
+        height={15}
+        className="rounded-sm"
+      />
+      {targetLabel}
     </button>
   );
 }

--- a/src/components/leaderboard/WorldRankingsContent.tsx
+++ b/src/components/leaderboard/WorldRankingsContent.tsx
@@ -33,43 +33,63 @@ export function WorldRankingsContent() {
 
   const highScore = progress?.quizHighScore ?? 0;
 
-  // Initial load
+  // Effect A — public leaderboard data (no auth dependency, runs once on mount).
+  // Fetching top entries and total count is safe without auth since the leaderboard
+  // collection is publicly readable. This avoids any race with Firebase auth init.
   useEffect(() => {
-    if (authLoading || !uid) return;
-    async function load() {
+    let cancelled = false;
+    async function loadPublic() {
       setLoading(true);
       setFetchError(false);
       try {
-        const [top, count, rank] = await Promise.all([
+        const [top, count] = await Promise.all([
           getTopLeaderboard(50),
           getLeaderboardCount(),
-          getUserRank(highScore),
         ]);
-
+        if (cancelled) return;
         setTopEntries(top.slice(0, 3));
         setListEntries(top.slice(3, 3 + PAGE_SIZE));
         setTotal(count);
-        setUserRank(rank);
-
-        // Find the score of the person just above the user
-        if (rank > 1 && top.length >= rank - 1) {
-          setNextRankScore(top[rank - 2]?.quizHighScore ?? null);
-        } else {
-          setNextRankScore(null);
-        }
-
         setHasMore(top.length > 3 + PAGE_SIZE);
         if (top.length > 0) {
           setLastScore(top[top.length - 1].quizHighScore);
         }
       } catch {
-        setFetchError(true);
+        if (!cancelled) setFetchError(true);
       } finally {
-        setLoading(false);
+        if (!cancelled) setLoading(false);
       }
     }
-    void load();
-  }, [highScore, authLoading, uid]);
+    void loadPublic();
+    return () => { cancelled = true; };
+  }, []);
+
+  // Effect B — user rank (only runs after auth and progress are both fully ready).
+  // Guarding on `progress !== null` (not just `uid`) prevents fetching with
+  // highScore=0 while progress is still loading, which would return rank=0 and
+  // then trigger a second fetch when progress finally loads.
+  useEffect(() => {
+    if (authLoading || !uid || progress === null) return;
+    let cancelled = false;
+    async function loadUserRank() {
+      try {
+        const rank = await getUserRank(highScore);
+        if (cancelled) return;
+        setUserRank(rank);
+        // Derive the score of the person just above the user from the already-loaded
+        // topEntries snapshot (avoids an extra Firestore round-trip).
+        if (rank > 1 && topEntries.length >= rank - 1) {
+          setNextRankScore(topEntries[rank - 2]?.quizHighScore ?? null);
+        } else {
+          setNextRankScore(null);
+        }
+      } catch {
+        // Rank fetch failure is non-fatal — the public leaderboard is still shown.
+      }
+    }
+    void loadUserRank();
+    return () => { cancelled = true; };
+  }, [authLoading, uid, progress, highScore, topEntries]);
 
   const handleLoadMore = useCallback(async () => {
     if (loadingMore || !hasMore || lastScore === undefined) return;


### PR DESCRIPTION
## Summary

Fixes two production bugs: language selector flags not rendering on Windows, and the Rankings page showing an error state after a page refresh.

Closes #100
Closes #101

---

## Bug 1 — Language Selector Flags Not Rendering (#100)

### Root cause
`LanguageToggle.tsx` used Unicode Regional Indicator Sequences (🇪🇸, 🇬🇧) as flag icons. On **Windows**, the OS font stack does not support flag emoji — it falls back to displaying the raw two-letter regional indicator characters as plain text (`"ES"` / `"GB"`). This explains why users on shared links or first visits (often on Windows machines) saw plain text instead of flag icons.

### Fix
Replaced emoji with `next/image` `<Image>` components pointing to `https://flagcdn.com/w20/<code>.png`, consistent with every other flag in the app (`CountryCard`, `CountryHero`, `FlagDisplay`). The `flagcdn.com` domain was already whitelisted in `next.config.ts`.

### File changed
- `src/components/layout/LanguageToggle.tsx`

---

## Bug 2 — Rankings View Randomly Fails After Refresh (#101)

### Root cause
Three compounding issues in `WorldRankingsContent.tsx`:

1. **Premature `authLoading = false`**: When Firestore cold-starts on page refresh, `getUserProgress()` can throw. The `catch` block fires, then `finally { setLoading(false) }` unblocks the leaderboard — with `uid` set but `progress = null`.

2. **`highScore` in effect deps caused double-fire**: `highScore` started at `0` (progress null) → effect fired → then when progress loaded, `highScore` changed → effect fired again. Two concurrent fetches raced; either one could set `fetchError = true`.

3. **`getCountFromServer` bypasses Firestore cache**: On the same cold connection that caused issue #1, aggregate count queries fail directly, immediately setting `fetchError = true`.

### Fix
Split the single `useEffect` into two independent effects:

- **Effect A (public data, deps `[]`)**: Fetches `getTopLeaderboard(50)` + `getLeaderboardCount()` immediately on mount, with no auth dependency. The leaderboard collection is publicly readable per Firestore rules, so this is safe. Includes a `cancelled` stale-load guard.

- **Effect B (user rank, runs after auth)**: Fetches `getUserRank(highScore)` only when `!authLoading && uid && progress !== null`. The `progress !== null` guard prevents the `highScore = 0` false-negative that caused the double-fire. Failure here is non-fatal — the public leaderboard is still displayed.

This means:
- The rankings table loads immediately, without waiting for Firebase auth
- The user's personal rank populates once auth settles
- A slow/failed Firestore auth init no longer prevents the public rankings from loading
- Stale concurrent loads cannot overwrite each other's state

### File changed
- `src/components/leaderboard/WorldRankingsContent.tsx`

---

## Testing
- Both modified files: no lint errors
- Full test suite: 157/158 pass (1 pre-existing failure in `useGlobeData` fallback test, unrelated to this change)
- Production build: clean
