### PR TITLE
feat(layout): add subtle creator badge to bottom-right corner

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -211,5 +211,8 @@
     "reset": "Reset view",
     "geolocationError": "Could not detect your location",
     "loadingMap": "Loading map… {loaded} / {total}"
+  },
+  "creatorBadge": {
+    "visitCreator": "Visit the Creator"
   }
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -209,5 +209,8 @@
     "reset": "Restablecer vista",
     "geolocationError": "No se pudo detectar tu ubicación",
     "loadingMap": "Cargando mapa… {loaded} / {total}"
+  },
+  "creatorBadge": {
+    "visitCreator": "Visita al creador"
   }
 }

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -5,6 +5,7 @@ import { notFound } from "next/navigation";
 import { routing } from "@/i18n/routing";
 import { CountriesProvider } from "@/lib/providers/CountriesProvider";
 import { OnboardingGuard } from "@/components/auth/OnboardingGuard";
+import { CreatorBadge } from "@/components/layout/CreatorBadge";
 import "../globals.css";
 
 export function generateStaticParams() {
@@ -54,6 +55,7 @@ export default async function LocaleLayout({
           <CountriesProvider>
             <OnboardingGuard />
             {children}
+            <CreatorBadge />
           </CountriesProvider>
         </NextIntlClientProvider>
       </body>

--- a/src/components/layout/CreatorBadge.tsx
+++ b/src/components/layout/CreatorBadge.tsx
@@ -1,0 +1,20 @@
+import { getTranslations } from "next-intl/server";
+
+export async function CreatorBadge() {
+  const t = await getTranslations("creatorBadge");
+
+  return (
+    <a
+      href="https://personal-engineering-hub.vercel.app/"
+      target="_blank"
+      rel="noopener noreferrer"
+      className="fixed bottom-20 right-4 lg:bottom-6 lg:right-6 z-50 flex items-center gap-1.5 rounded-full px-3 py-1.5 bg-white/15 backdrop-blur-md border border-white/25 text-white text-xs font-medium transition-all duration-300 ease-out hover:bg-white/25 hover:scale-105"
+      aria-label={t("visitCreator")}
+    >
+      <span>{t("visitCreator")}</span>
+      <span className="material-symbols-outlined" style={{ fontSize: 14 }}>
+        open_in_new
+      </span>
+    </a>
+  );
+}


### PR DESCRIPTION
## Summary
Adds a small frosted-glass "Visit the Creator" pill badge fixed to the bottom-right corner of every page.

## Changes
- **New:** `src/components/layout/CreatorBadge.tsx` — server component, no `"use client"` needed
- **Updated:** `src/app/[locale]/layout.tsx` — one-line import + render after `{children}`
- **Updated:** `messages/en.json` + `messages/es.json` — `creatorBadge.visitCreator` key

## Visual Design
- Frosted glass pill: `bg-white/15 backdrop-blur-md border-white/25` — visible on both the blue gradient and the dark map (`#0A0E27`)
- Hover: `scale-105` + `bg-white/25` with 300ms ease-out transition
- Mobile: `bottom-20` keeps it above BottomNav; desktop: `bottom-6`
- `open_in_new` icon (14px) next to label

## Verification
- [x] Build passes (no TS errors)
- [x] 157/158 tests pass (1 pre-existing `useGlobeData` failure, unrelated)
- [x] All pages covered via locale layout

Closes #105