### PR TITLE
fix(layout): apply creator badge size refinements and fix globe controls overlap

### DIFF
--- a/src/components/layout/CreatorBadge.tsx
+++ b/src/components/layout/CreatorBadge.tsx
@@ -8,11 +8,11 @@ export async function CreatorBadge() {
       href="https://personal-engineering-hub.vercel.app/"
       target="_blank"
       rel="noopener noreferrer"
-      className="fixed bottom-20 right-4 lg:bottom-6 lg:right-6 z-50 flex items-center gap-1.5 rounded-full px-3 py-1.5 bg-white/15 backdrop-blur-md border border-white/25 text-white text-xs font-medium transition-all duration-300 ease-out hover:bg-white/25 hover:scale-105"
+      className="fixed bottom-20 right-2 lg:bottom-2 lg:right-2 z-50 flex items-center gap-1 rounded-full px-2 py-1 bg-white/10 backdrop-blur-md border border-white/20 text-white text-[10px] transition-all duration-300 ease-out hover:bg-white/20 hover:scale-105"
       aria-label={t("visitCreator")}
     >
       <span>{t("visitCreator")}</span>
-      <span className="material-symbols-outlined" style={{ fontSize: 14 }}>
+      <span className="material-symbols-outlined" style={{ fontSize: 12 }}>
         open_in_new
       </span>
     </a>

--- a/src/components/map/GlobeControls.tsx
+++ b/src/components/map/GlobeControls.tsx
@@ -26,7 +26,7 @@ export function GlobeControls({
     "w-12 h-12 bg-black/40 backdrop-blur-xl border border-white/10 rounded-2xl flex items-center justify-center text-white/80 hover:bg-white/20 hover:text-white transition-all duration-200";
 
   return (
-    <div className="absolute bottom-8 right-8 z-10 flex flex-col gap-3">
+    <div className="absolute bottom-12 right-8 z-10 flex flex-col gap-3">
       <button
         onClick={onToggleDaylight}
         className={btnBase}


### PR DESCRIPTION
## What

The badge size/position refinements from the original #105 task were not included in the squash merge of PR #106. The deployed badge is too large and not tight enough to the corner.

## Changes

- `CreatorBadge.tsx`: Reduce to `text-[10px]`, `px-2 py-1`, icon 12px, position `lg:bottom-2 lg:right-2`, opacity `bg-white/10 border-white/20`
- `GlobeControls.tsx`: Raise from `bottom-8` to `bottom-12` to prevent overlap with badge

Fixes #107