### PR TITLE
fix(images): reduce Vercel transformation usage

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -54,7 +54,8 @@
     "subtitle": "Your digital field guide to the wonders of our planet. Explore histories, flags, and cultures across all seven continents.",
     "capitalLabel": "Capital City",
     "populationLabel": "Population",
-    "exploreCulture": "Explore Culture"
+    "exploreCulture": "Explore Culture",
+    "loadMore": "Load More Countries"
   },
   "country": {
     "spotlight": "Country Spotlight",

--- a/messages/es.json
+++ b/messages/es.json
@@ -54,7 +54,8 @@
     "subtitle": "Tu guía digital de las maravillas de nuestro planeta. Explora historias, banderas y culturas de los siete continentes.",
     "capitalLabel": "Capital",
     "populationLabel": "Población",
-    "exploreCulture": "Explorar Cultura"
+    "exploreCulture": "Explorar Cultura",
+    "loadMore": "Mostrar más países"
   },
   "country": {
     "spotlight": "País Destacado",

--- a/next.config.ts
+++ b/next.config.ts
@@ -3,12 +3,10 @@ import createNextIntlPlugin from "next-intl/plugin";
 
 const nextConfig: NextConfig = {
   images: {
+    minimumCacheTTL: 2_678_400,
+    formats: ["image/webp"],
+    qualities: [75],
     remotePatterns: [
-      {
-        protocol: "https",
-        hostname: "flagcdn.com",
-        pathname: "/**",
-      },
       {
         protocol: "https",
         hostname: "images.unsplash.com",

--- a/src/__tests__/app/[locale]/catalog/CatalogContent.test.tsx
+++ b/src/__tests__/app/[locale]/catalog/CatalogContent.test.tsx
@@ -1,0 +1,132 @@
+import { useState } from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { CatalogContent } from "@/app/[locale]/catalog/CatalogContent";
+import type { Continent, Country } from "@/data/types";
+
+const mockUseCountries = vi.fn();
+const mockUseContinentFilter = vi.fn();
+
+function createMockCountry(index: number, continent: Continent, name = `Country ${index}`): Country {
+  return {
+    slug: `country-${index}`,
+    flagCode: `c${index}`,
+    continent,
+    population: `${index}M`,
+    region: `Region ${index}`,
+    name,
+    capital: `Capital ${index}`,
+    flagDescription: `Flag description ${index}`,
+    funFacts: [],
+  };
+}
+
+const mockCountries: Country[] = [
+  createMockCountry(1, "Europe", "Afghanistan"),
+  ...Array.from({ length: 29 }, (_, index) => createMockCountry(index + 2, "Europe")),
+  ...Array.from({ length: 10 }, (_, index) => createMockCountry(index + 31, "Asia")),
+];
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+vi.mock("@/lib/providers/CountriesProvider", () => ({
+  useCountries: () => mockUseCountries(),
+}));
+
+vi.mock("@/lib/hooks/useContinentFilter", () => ({
+  useContinentFilter: () => mockUseContinentFilter(),
+}));
+
+vi.mock("@/components/layout/AppShell", () => ({
+  AppShell: ({
+    children,
+    searchQuery,
+    onSearchChange,
+    onContinentSelect,
+  }: {
+    children: React.ReactNode;
+    searchQuery?: string;
+    onSearchChange?: (value: string) => void;
+    onContinentSelect?: (continent: "Europe" | null) => void;
+  }) => (
+    <div>
+      <label htmlFor="catalog-search">catalog-search</label>
+      <input
+        id="catalog-search"
+        value={searchQuery ?? ""}
+        onChange={(event) => onSearchChange?.(event.target.value)}
+      />
+      <button type="button" onClick={() => onContinentSelect?.("Europe") }>
+        continent-filter
+      </button>
+      {children}
+    </div>
+  ),
+}));
+
+vi.mock("@/components/catalog/CountryGrid", () => ({
+  CountryGrid: ({ countries }: { countries: Array<{ slug: string; name: string }> }) => (
+    <div>
+      {countries.map((country) => (
+        <button key={country.slug} type="button" aria-label="exploreCulture">
+          {country.name}
+        </button>
+      ))}
+    </div>
+  ),
+}));
+
+describe("CatalogContent", () => {
+  beforeEach(() => {
+    mockUseCountries.mockReset();
+    mockUseContinentFilter.mockReset();
+
+    mockUseCountries.mockReturnValue({
+      countries: mockCountries,
+    });
+
+    mockUseContinentFilter.mockImplementation(() => {
+      const [activeContinent, setContinent] = useState<Continent | null>(null);
+
+      return {
+        activeContinent,
+        setContinent,
+      };
+    });
+  });
+
+  it("renders an initial batch, expands on demand, and resets when search or continent changes", async () => {
+    render(<CatalogContent />);
+
+    expect(screen.getAllByRole("button", { name: "exploreCulture" })).toHaveLength(24);
+
+    fireEvent.click(screen.getByRole("button", { name: "loadMore" }));
+
+    expect(screen.getAllByRole("button", { name: "exploreCulture" })).toHaveLength(40);
+
+    fireEvent.change(screen.getByLabelText("catalog-search"), {
+      target: { value: "Afghanistan" },
+    });
+
+    expect(screen.getAllByRole("button", { name: "exploreCulture" })).toHaveLength(1);
+    expect(screen.queryByRole("button", { name: "loadMore" })).not.toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText("catalog-search"), {
+      target: { value: "" },
+    });
+
+    expect(screen.getAllByRole("button", { name: "exploreCulture" })).toHaveLength(24);
+    expect(screen.getByRole("button", { name: "loadMore" })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "loadMore" }));
+
+    expect(screen.getAllByRole("button", { name: "exploreCulture" })).toHaveLength(40);
+
+    fireEvent.click(screen.getByRole("button", { name: "continent-filter" }));
+
+    expect(screen.getAllByRole("button", { name: "exploreCulture" })).toHaveLength(24);
+    expect(screen.getByRole("button", { name: "loadMore" })).toBeInTheDocument();
+  });
+});

--- a/src/app/[locale]/catalog/CatalogContent.tsx
+++ b/src/app/[locale]/catalog/CatalogContent.tsx
@@ -1,18 +1,49 @@
 "use client";
 
-import { useState, useMemo } from "react";
+import { useMemo, useState } from "react";
 import { useTranslations } from "next-intl";
 import { useCountries } from "@/lib/providers/CountriesProvider";
 import { filterByContinent, searchCountries } from "@/lib/utils/countries";
 import { useContinentFilter } from "@/lib/hooks/useContinentFilter";
 import { AppShell } from "@/components/layout/AppShell";
 import { CountryGrid } from "@/components/catalog/CountryGrid";
+import { Button } from "@/components/ui/Button";
+import type { Continent, Country } from "@/data/types";
+
+const CATALOG_PAGE_SIZE = 24;
+
+type CatalogResultsProps = {
+  countries: Country[];
+  loadMoreLabel: string;
+};
+
+function CatalogResults({ countries, loadMoreLabel }: CatalogResultsProps) {
+  const [visibleCount, setVisibleCount] = useState(CATALOG_PAGE_SIZE);
+  const visibleCountries = countries.slice(0, visibleCount);
+  const canLoadMore = visibleCountries.length < countries.length;
+
+  return (
+    <>
+      <CountryGrid countries={visibleCountries} />
+      {canLoadMore ? (
+        <div className="mt-10 flex justify-center">
+          <Button
+            type="button"
+            onClick={() => setVisibleCount((currentCount) => currentCount + CATALOG_PAGE_SIZE)}
+          >
+            {loadMoreLabel}
+          </Button>
+        </div>
+      ) : null}
+    </>
+  );
+}
 
 export function CatalogContent() {
   const t = useTranslations("catalog");
   const { countries } = useCountries();
   const [searchQuery, setSearchQuery] = useState("");
-  const { activeContinent } = useContinentFilter();
+  const { activeContinent, setContinent } = useContinentFilter();
 
   const filteredCountries = useMemo(() => {
     let result = filterByContinent(countries, activeContinent);
@@ -20,8 +51,22 @@ export function CatalogContent() {
     return result;
   }, [countries, activeContinent, searchQuery]);
 
+  const paginationKey = `${activeContinent ?? "all"}:${searchQuery}`;
+
+  function handleSearchChange(value: string) {
+    setSearchQuery(value);
+  }
+
+  function handleContinentSelect(continent: Continent | null) {
+    setContinent(continent);
+  }
+
   return (
-    <AppShell searchQuery={searchQuery} onSearchChange={setSearchQuery}>
+    <AppShell
+      searchQuery={searchQuery}
+      onSearchChange={handleSearchChange}
+      onContinentSelect={handleContinentSelect}
+    >
       <header className="mb-12">
         <h1 className="text-5xl md:text-6xl font-extrabold text-on-background tracking-tighter mb-4">
           {t("title")}
@@ -30,7 +75,11 @@ export function CatalogContent() {
           {t("subtitle")}
         </p>
       </header>
-      <CountryGrid countries={filteredCountries} />
+      <CatalogResults
+        key={paginationKey}
+        countries={filteredCountries}
+        loadMoreLabel={t("loadMore")}
+      />
     </AppShell>
   );
 }

--- a/src/components/catalog/CountryCard.tsx
+++ b/src/components/catalog/CountryCard.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import Image from "next/image";
 import { useTranslations } from "next-intl";
 import { Link } from "@/i18n/navigation";
 import { Country } from "@/data/types";
@@ -19,12 +18,18 @@ export function CountryCard({ country }: CountryCardProps) {
       className="group bg-surface-container-low rounded-xl overflow-hidden hover:scale-[1.02] transition-bounce shadow-ambient flex flex-col"
     >
       <div className="relative h-48 overflow-hidden bg-surface-container-highest">
-        <Image
-          src={`https://flagcdn.com/w320/${country.flagCode}.png`}
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          src={`https://flagcdn.com/w640/${country.flagCode}.png`}
+          srcSet={[
+            `https://flagcdn.com/w320/${country.flagCode}.png 320w`,
+            `https://flagcdn.com/w640/${country.flagCode}.png 640w`,
+            `https://flagcdn.com/w1280/${country.flagCode}.png 1280w`,
+          ].join(", ")}
           alt={`Flag of ${country.name}`}
-          fill
-          className="object-cover group-hover:scale-110 transition-transform duration-500"
+          className="h-full w-full object-cover group-hover:scale-110 transition-transform duration-500"
           sizes="(max-width: 640px) 100vw, (max-width: 1280px) 50vw, 33vw"
+          loading="lazy"
         />
       </div>
       <div className="p-6 flex-1 flex flex-col">

--- a/src/components/country/CountryHero.tsx
+++ b/src/components/country/CountryHero.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import Image from "next/image";
 import { useTranslations } from "next-intl";
 import { Country } from "@/data/types";
 
@@ -15,13 +14,17 @@ export function CountryHero({ country }: CountryHeroProps) {
       <div className="flex flex-col lg:flex-row items-end gap-8">
         {/* Flag image */}
         <div className="relative w-full lg:w-2/3 aspect-video rounded-xl overflow-hidden shadow-ambient-lg">
-          <Image
-            src={`https://flagcdn.com/w640/${country.flagCode}.png`}
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={`https://flagcdn.com/w1280/${country.flagCode}.png`}
+            srcSet={[
+              `https://flagcdn.com/w640/${country.flagCode}.png 640w`,
+              `https://flagcdn.com/w1280/${country.flagCode}.png 1280w`,
+            ].join(", ")}
             alt={t("flagAlt", { name: country.name })}
-            fill
-            className="object-cover"
-            priority
+            className="h-full w-full object-cover"
             sizes="(max-width: 1024px) 100vw, 66vw"
+            fetchPriority="high"
           />
           <div className="absolute inset-0 bg-gradient-to-t from-black/40 to-transparent" />
           <div className="absolute bottom-8 left-8">

--- a/src/components/games/FlagDisplay.tsx
+++ b/src/components/games/FlagDisplay.tsx
@@ -1,4 +1,3 @@
-import Image from "next/image";
 import { Country } from "@/data/types";
 
 type FlagDisplayProps = {
@@ -7,13 +6,15 @@ type FlagDisplayProps = {
 
 export function FlagDisplay({ country }: FlagDisplayProps) {
   return (
-    <Image
+    // eslint-disable-next-line @next/next/no-img-element
+    <img
       src={`https://flagcdn.com/w640/${country.flagCode}.png`}
       alt="Mystery flag — guess which country!"
       width={384}
       height={256}
       className="rounded-lg object-contain w-auto h-auto max-w-full max-h-[350px]"
-      priority
+      loading="eager"
+      fetchPriority="high"
     />
   );
 }

--- a/src/components/layout/LanguageToggle.tsx
+++ b/src/components/layout/LanguageToggle.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import Image from "next/image";
 import { useLocale } from "next-intl";
 import { useRouter, usePathname } from "@/i18n/navigation";
 
@@ -26,7 +25,8 @@ export function LanguageToggle() {
       className="flex items-center gap-1.5 px-3 py-1.5 bg-surface-container-high rounded-full text-sm font-bold text-on-surface hover:bg-surface-container-highest transition-bounce"
       aria-label={ariaLabel}
     >
-      <Image
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img
         src={`https://flagcdn.com/w20/${targetFlag}.png`}
         alt={targetLabel}
         width={20}


### PR DESCRIPTION
## Summary
- reduce Vercel image transformations by moving FlagCDN flag surfaces off the Next image optimizer
- batch the catalog page to 24 countries at a time with localized Load More behavior
- add focused regression coverage for catalog pagination reset behavior

## Test Plan
- [x] npm test
- [x] npm run build

Closes #109