### PR TITLE
test(globe): stabilize hi-res fallback coverage

### DIFF
--- a/src/__tests__/hooks/useGlobeData.test.ts
+++ b/src/__tests__/hooks/useGlobeData.test.ts
@@ -197,12 +197,13 @@ describe("useGlobeData", () => {
     const { result } = renderHook(() => useGlobeData());
 
     await waitFor(() => {
+      expect(geoModule.loadWorldTopology).toHaveBeenCalled();
       expect(result.current.upgrading).toBe(false);
+      expect(result.current.countries.length).toBeGreaterThan(0);
     });
 
     // Hi-res topology was used as fallback
-    expect(geoModule.loadWorldTopology).toHaveBeenCalled();
-    expect(result.current.countries.length).toBeGreaterThan(0);
+    expect(result.current.countries[0].flagCode).toBe("us");
   });
 
   it("falls back to topology loading when precomputed files are unavailable", async () => {


### PR DESCRIPTION
## Summary
- fix the flaky hi-res fallback assertion in useGlobeData test coverage
- wait for the fallback loader to populate countries before asserting results

## Test Plan
- [x] npm test -- "src/__tests__/hooks/useGlobeData.test.ts"
- [x] npm test
- [x] npm run build

Closes #111